### PR TITLE
OPS file to remove default cf-deployment URI wildcards for uaa and login

### DIFF
--- a/bosh/opsfiles/remove-uaa-wildcard.yml
+++ b/bosh/opsfiles/remove-uaa-wildcard.yml
@@ -1,0 +1,9 @@
+#This OPS file removes the *.uaa and *.login URIs from the cf-deployment.yml base as CG does not use those URIs
+- type: remove
+  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar/routes/0/uris
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar/routes/0/uris?
+  value:
+    - uaa.((system_domain))
+    - login.((system_domain))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Simple OPS file that removes wildcard URIs for uaa route-register job
- Due to the array only being values and not name & value the best is to remove the array and add back a new array with just the values we want
-

## security considerations
[Note the any security considerations here, or make note of why there are none]
