### PR TITLE
changing out for more memory with same cpu.

### DIFF
--- a/bosh/opsfiles/scaling-production.yml
+++ b/bosh/opsfiles/scaling-production.yml
@@ -79,7 +79,7 @@
   value: 10
 - type: replace
   path: /instance_groups/name=doppler/vm_type
-  value: c5.2xlarge
+  value: m5.2xlarge
 
 # log-api
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- doppler has been running high for awhile, this should fix that.
- 8 cpu and 32G of memory (up from 16G)

## security considerations
[Note the any security considerations here, or make note of why there are none]

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>