### PR TITLE
Disable internal user mgmt

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -259,6 +259,35 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
+- name: uaa-security-tests-development
+  plan:
+  - in_parallel:
+    - get: cf-deployment-development
+      trigger: true
+      passed: [deploy-cf-development]
+    - get: cf-deployment
+      trigger: true
+      passed: [deploy-cf-development]
+    - get: cf-manifests
+      trigger: true
+      passed: [deploy-cf-development]
+    - get: uaa-customized-release
+      trigger: true
+      passed: [deploy-cf-development]
+  - task: uaa-integration-tests
+    file: cf-manifests/ci/uaa-disabled-endpoint-tests.yml
+    params:
+      UAA_URL: ((uaa-url-development))
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Integration Tests for CF on development FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
 - name: smoke-tests-development
   serial_groups: [development]
   plan:
@@ -1165,6 +1194,7 @@ groups:
   - uaa-smoke-tests-development
   - uaa-client-audit-development
   - tic-smoke-tests-development
+  - uaa-security-tests-development
   - smoke-tests-development
 - name: staging
   jobs:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -145,73 +145,6 @@ jobs:
       <<: *tf-development
       TERRAFORM_ACTION: apply
 
-- name: smoke-tests-development
-  serial_groups: [development]
-  plan:
-  - in_parallel:
-    - get: common
-      resource: master-bosh-root-cert
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
-      trigger: true
-    - get: cf-deployment-development
-      trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
-    - get: cf-deployment
-      trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
-    - get: cf-stemcell-xenial
-      trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
-    - get: cf-manifests
-      trigger: true
-    - get: uaa-customized-release
-      trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
-    - get: cg-s3-secureproxy-release
-      trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
-  - task: run-errand
-    attempts: 3
-    params:
-      BOSH_ENVIRONMENT: ((bosh.development.environment))
-      BOSH_CLIENT: ((bosh.development.client))
-      BOSH_CLIENT_SECRET: ((bosh.development.client-secret))
-      BOSH_DEPLOYMENT: ((cf.development.name))
-      BOSH_ERRAND: ((cf.development.smoke-tests))
-      BOSH_CA_CERT: common/master-bosh.crt
-    config: &smoke-tests-errand
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: 18fgsa/concourse-task
-      inputs:
-        - name: common
-      run:
-        path: /bin/bash
-        args:
-        - -euxc
-        - | 
-          bosh run-errand smoke-tests
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Smoke Tests for CF on development PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: Smoke Tests for CF on development FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
 - name: uaa-smoke-tests-development
   plan:
   - in_parallel:
@@ -321,6 +254,73 @@ jobs:
     params:
       text: |
         :x: TIC Smoke Tests for CF on development FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
+- name: smoke-tests-development
+  serial_groups: [development]
+  plan:
+  - in_parallel:
+    - get: common
+      resource: master-bosh-root-cert
+      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      trigger: true
+    - get: cf-deployment-development
+      trigger: true
+      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+    - get: cf-deployment
+      trigger: true
+      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+    - get: cf-stemcell-xenial
+      trigger: true
+      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+    - get: cf-manifests
+      trigger: true
+    - get: uaa-customized-release
+      trigger: true
+      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+    - get: cg-s3-secureproxy-release
+      trigger: true
+      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+  - task: run-errand
+    attempts: 3
+    params:
+      BOSH_ENVIRONMENT: ((bosh.development.environment))
+      BOSH_CLIENT: ((bosh.development.client))
+      BOSH_CLIENT_SECRET: ((bosh.development.client-secret))
+      BOSH_DEPLOYMENT: ((cf.development.name))
+      BOSH_ERRAND: ((cf.development.smoke-tests))
+      BOSH_CA_CERT: common/master-bosh.crt
+    config: &smoke-tests-errand
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: 18fgsa/concourse-task
+      inputs:
+        - name: common
+      run:
+        path: /bin/bash
+        args:
+        - -euxc
+        - | 
+          bosh run-errand smoke-tests
+  on_success:
+    put: slack
+    params:
+      text: |
+        :white_check_mark: Smoke Tests for CF on development PASSED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Smoke Tests for CF on development FAILED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: ((slack-channel))
       username: ((slack-username))

--- a/ci/uaa-disabled-endpoint-tests.sh
+++ b/ci/uaa-disabled-endpoint-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Tests various UAA endpoints for known vulnerabilities. 
+# See: https://github.com/cloud-gov/private/issues/117
+
+set -e
+
+# Endpoint should be disabled (GET): /create_account 
+status_code=$(curl --silent --output /dev/null -w "%{http_code}" ${UAA_URL}/create_account)
+if [[ "${status_code}" != "404" ]]; then
+  echo "ERROR: Endpoint /create_account returned incorrect status code. Expected: 404, Got: ${status_code}"
+  exit 1
+fi
+
+# Endpoint should be disabled (POST): /create_account.do 
+status_code=$(curl -X POST --silent --output /dev/null -w "%{http_code}" ${UAA_URL}/create_account.do --data-urlencode client_id=client-id --data-urlencode redirect_uri=redirect-uri --data-urlencode password=password1 --data-urlencode password_confirmation=password1 --data-urlencode email=test@example.com)
+if [[ "${status_code}" != "404" ]]; then
+  echo "ERROR: POST to endpoint /create_account.do returned incorrect status code. Expected: 404, Got: ${status_code}"
+  exit 1
+fi

--- a/ci/uaa-disabled-endpoint-tests.yml
+++ b/ci/uaa-disabled-endpoint-tests.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: 18fgsa/concourse-task
+
+inputs:
+- name: cf-manifests
+
+run:
+  path: cf-manifests/ci/uaa-disabled-endpoint-tests.sh
+
+params:
+  UAA_URL: 


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds checks to ensure the self service user creation URLs are not active.  See: https://github.com/cloud-gov/private/issues/117#issuecomment-583043399

This commit purposely omits the configuration fix to disable the self service URLs as I want to be sure the concourse job fails before fixing it. Similarly, the new job is not a gating factor in the promotion flow currently as I don't want this to be a blocker until the fix is in place.

## security considerations

This check ensures potentially vulnerable endpoints are not active. 

The sample email and password in the test payload of the second curl request are not real credentials.
