### PR TITLE
Disable internal user mgmt

### DIFF
--- a/bosh/opsfiles/uaa-login.yml
+++ b/bosh/opsfiles/uaa-login.yml
@@ -33,3 +33,8 @@
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login?/self_service_links_enabled?
   value: true
+
+# 
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/disableInternalUserManagement?
+  value: true

--- a/bosh/opsfiles/uaa-login.yml
+++ b/bosh/opsfiles/uaa-login.yml
@@ -37,4 +37,4 @@
 # 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/disableInternalUserManagement?
-  value: true
+  value: ((disable_internal_user_management))

--- a/bosh/varsfiles/development.yml
+++ b/bosh/varsfiles/development.yml
@@ -9,3 +9,5 @@ buildpack_directory_key: cf-development-buildpacks
 droplet_directory_key: cf-development-droplets
 app_package_directory_key: cf-development-cc-packages
 resource_directory_key: cf-development-cc-resources
+
+disable_internal_user_management: true

--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -9,3 +9,5 @@ buildpack_directory_key: cf-production-buildpacks
 droplet_directory_key: cf-production-droplets
 app_package_directory_key: cf-production-cc-packages
 resource_directory_key: cf-production-cc-resources
+
+disable_internal_user_management: false

--- a/bosh/varsfiles/staging.yml
+++ b/bosh/varsfiles/staging.yml
@@ -9,3 +9,5 @@ buildpack_directory_key: cf-staging-buildpacks
 droplet_directory_key: cf-staging-droplets
 app_package_directory_key: cf-staging-cc-packages
 resource_directory_key: cf-staging-cc-resources
+
+disable_internal_user_management: false

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -282,7 +282,7 @@ jobs:
     put: slack
     params:
       text: |
-        :x: Integration Tests for CF on development FAILED
+        :x: UAA Security Tests for CF on development FAILED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: ((slack-channel))
       username: ((slack-username))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1169,6 +1169,7 @@ groups:
   - uaa-smoke-tests-development
   - uaa-client-audit-development
   - tic-smoke-tests-development
+  - uaa-security-tests-development
   - smoke-tests-development
   - deploy-cf-staging
   - terraform-plan-staging

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -298,10 +298,10 @@ jobs:
       trigger: true
     - get: cf-deployment-development
       trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      passed: [tic-smoke-tests-development,uaa-smoke-tests-development,uaa-security-tests-development]
     - get: cf-deployment
       trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      passed: [tic-smoke-tests-development,uaa-smoke-tests-development,uaa-security-tests-development]
     - get: cf-stemcell-xenial
       trigger: true
       passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
@@ -309,7 +309,7 @@ jobs:
       trigger: true
     - get: uaa-customized-release
       trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      passed: [tic-smoke-tests-development,uaa-smoke-tests-development,uaa-security-tests-development]
     - get: cg-s3-secureproxy-release
       trigger: true
       passed: [tic-smoke-tests-development,uaa-smoke-tests-development]

--- a/ci/uaa-disabled-endpoint-tests.sh
+++ b/ci/uaa-disabled-endpoint-tests.sh
@@ -6,14 +6,26 @@
 set -e
 
 # Endpoint should be disabled (GET): /create_account 
-status_code=$(curl --silent --output /dev/null -w "%{http_code}" ${UAA_URL}/create_account)
+status_code=$(curl --silent \
+  --output /dev/null \
+  -w "%{http_code}" \
+  ${UAA_URL}/create_account)
 if [[ "${status_code}" != "404" ]]; then
   echo "ERROR: Endpoint /create_account returned incorrect status code. Expected: 404, Got: ${status_code}"
   exit 1
 fi
 
 # Endpoint should be disabled (POST): /create_account.do 
-status_code=$(curl -X POST --silent --output /dev/null -w "%{http_code}" ${UAA_URL}/create_account.do --data-urlencode client_id=client-id --data-urlencode redirect_uri=redirect-uri --data-urlencode password=password1 --data-urlencode password_confirmation=password1 --data-urlencode email=test@example.com)
+status_code=$(curl -X POST \
+  --silent \
+  --output /dev/null \
+  -w "%{http_code}" \
+  ${UAA_URL}/create_account.do \
+  --data-urlencode client_id=client-id \
+  --data-urlencode redirect_uri=redirect-uri \
+  --data-urlencode password=password1 \
+  --data-urlencode password_confirmation=password1 \
+  --data-urlencode email=test@example.com)
 if [[ "${status_code}" != "404" ]]; then
   echo "ERROR: POST to endpoint /create_account.do returned incorrect status code. Expected: 404, Got: ${status_code}"
   exit 1


### PR DESCRIPTION
## Changes proposed in this pull request:

Disables the /create_account and /create_account.do endpoints on UAA according to: https://github.com/cloud-gov/private/issues/117

Makes the uaa-security-tests-development job a precursor to promotion (before dev smoke tests).

## security considerations

This should correct the potential vulernability identified here: https://github.com/cloud-gov/private/issues/117