### PR TITLE
enable uaa-security-tests in staging

### DIFF
--- a/bosh/varsfiles/staging.yml
+++ b/bosh/varsfiles/staging.yml
@@ -10,4 +10,4 @@ droplet_directory_key: cf-staging-droplets
 app_package_directory_key: cf-staging-cc-packages
 resource_directory_key: cf-staging-cc-resources
 
-disable_internal_user_management: false
+disable_internal_user_management: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -539,6 +539,35 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
+- name: uaa-security-tests-staging
+  plan:
+  - in_parallel:
+    - get: cf-deployment-staging
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: cf-deployment
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: cf-manifests
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: uaa-customized-release
+      trigger: true
+      passed: [deploy-cf-staging]
+  - task: uaa-integration-tests
+    file: cf-manifests/ci/uaa-disabled-endpoint-tests.yml
+    params:
+      UAA_URL: ((uaa-url-development))
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: UAA Security Tests for CF on staging FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
 - name: terraform-plan-staging
   plan:
   - in_parallel:
@@ -1177,6 +1206,7 @@ groups:
   - uaa-smoke-tests-staging
   - uaa-client-audit-staging
   - tic-smoke-tests-staging
+  - uaa-security-tests-staging
   - smoke-tests-staging
   - acceptance-tests-staging
   - deploy-cf-production
@@ -1205,6 +1235,7 @@ groups:
   - uaa-smoke-tests-staging
   - uaa-client-audit-staging
   - tic-smoke-tests-staging
+  - uaa-security-tests-staging
   - smoke-tests-staging
   - acceptance-tests-staging
 - name: production


### PR DESCRIPTION
## Changes proposed in this pull request:

Disables the create_account endpoints on uaa and tests to ensure this is enforced. This purposely only updates staging to ensure production is not affected. I will make the prod changes once the staging smoke tests pass (I can't figure out a better way to do this).

## security considerations

disables the create_account endpoints in staging according to: https://github.com/cloud-gov/private/issues/117
