### PR TITLE
remove deployment resource from client-audit jobs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -191,8 +191,6 @@ jobs:
     - get: cf-deployment
     - get: cf-manifests
       passed: [deploy-cf-development]
-    - get: cf-deployment-development
-      trigger: true
     - get: tests-timer
       trigger: true
   - task: uaa-client-audit
@@ -453,8 +451,6 @@ jobs:
     - get: cf-deployment
     - get: cf-manifests
       passed: [deploy-cf-staging]
-    - get: cf-deployment-staging
-      trigger: true
     - get: tests-timer
       trigger: true
   - task: uaa-client-audit
@@ -842,8 +838,6 @@ jobs:
     - get: cf-deployment
     - get: cf-manifests
       passed: [deploy-cf-production]
-    - get: cf-deployment-production
-      trigger: true
     - get: tests-timer
       trigger: true
   - task: uaa-client-audit


### PR DESCRIPTION
## Changes proposed in this pull request:
- don't use the deployment as an input. It's not used, and just creates conflicts

## security considerations
None