### PR TITLE
removing credhub variable definations for routing_api that where miss…

### DIFF
--- a/bosh/opsfiles/remove-routing-components-for-transition.yml
+++ b/bosh/opsfiles/remove-routing-components-for-transition.yml
@@ -30,3 +30,12 @@
 
 - type: remove
   path: /variables/name=diego_locket_client
+
+- type: remove
+  path: /variables/name=routing_api_ca
+
+- type: remove
+  path: /variables/name=routing_api_tls
+
+- type: remove
+  path: /variables/name=routing_api_tls_client


### PR DESCRIPTION
…ed in the int ops file

## Changes proposed in this pull request:
- Updated ops file to remove orphaned routing_api credhub certs not in use and giving false positives in credhub

## security considerations
none
