### PR TITLE
add replace block to remove reference to credhub_tls

### DIFF
--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -41,7 +41,7 @@
   path: /variables/name=uaa_clients_cc_service_key_client_secret
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_ca
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
   value:
     - ((diego_instance_identity_ca.ca))
     - ((uaa_ssl.ca))

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -39,3 +39,9 @@
 
 - type: remove
   path: /variables/name=uaa_clients_cc_service_key_client_secret
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_ca
+  value:
+    - ((diego_instance_identity_ca.ca))
+    - ((uaa_ssl.ca))


### PR DESCRIPTION
## Changes proposed in this pull request:

Removes a reference to `credhub_tls`. It appears we missed a reference to `credhub_tls` which should no longer be in use. We want to be able to remove this value from the environment credhubs. 

Existing reference is: https://github.com/cloudfoundry/cf-deployment/blob/50cfcf63e94b678a932516c277ece755cf1a140d/cf-deployment.yml#L1465

## security considerations

None. Should no longer be in use.
