### PR TITLE
increasing diego staging cell quota from 4 to 6 gb

### DIFF
--- a/bosh/opsfiles/api-defaults.yml
+++ b/bosh/opsfiles/api-defaults.yml
@@ -12,7 +12,7 @@
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?
-  value: 4096
+  value: 6144
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/client_max_body_size?

--- a/bosh/opsfiles/diego-cell-disk.yml
+++ b/bosh/opsfiles/diego-cell-disk.yml
@@ -1,3 +1,3 @@
 - type: replace
   path: /instance_groups/name=diego-cell/vm_extensions/0
-  value: 200GB_ephemeral_disk
+  value: 250GB_ephemeral_disk


### PR DESCRIPTION
## Changes proposed in this pull request:
- Increasing diego-cell staging disk quota from 4 to 6 GB
- Part of ticket: https://github.com/cloud-gov/cg-deploy-cf/issues/492

## security considerations
n/a