### PR TITLE
fix missing quota on 2nd CC job

### DIFF
--- a/bosh/opsfiles/api-defaults.yml
+++ b/bosh/opsfiles/api-defaults.yml
@@ -8,7 +8,7 @@
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_app_disk_in_mb?
-  value: 4096
+  value: 6144
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?


### PR DESCRIPTION
## Changes proposed in this pull request:
- Missed 2nd quota setting for CAPI to allow increase from 4 to 6 GB for apps

## security considerations
NA
