### PR TITLE
Add ci jobs to alert prometheus on to many uaa accounts created

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -12,7 +12,7 @@
   value:
     override: true
     authorized-grant-types: client_credentials
-    authorities: clients.read,cloud_controller.global_auditor
+    authorities: clients.read,scim.read,cloud_controller.global_auditor
     secret: ((uaa-client-audit-client-secret))
 
 - type: replace

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -202,6 +202,22 @@ jobs:
       GATEWAY_HOST: prometheus-staging.service.cf.internal
       WHITELIST: ((uaa-audit-whitelist-development))
 
+- name: uaa-monitor-account-creation-development
+  plan:
+  - in_parallel:
+    - get: cf-deployment
+    - get: cf-manifests
+      passed: [deploy-cf-development]
+    - get: hourly-timer
+      trigger: true
+  - task: uaa-monitor-account-creation
+    file: cf-manifests/ci/uaa-monitor-account-creation.yml
+    params:
+      UAA_URL: ((uaa-url-development))
+      UAA_CLIENT_ID: ((uaa-audit-client-id-development))
+      UAA_CLIENT_SECRET: ((uaa-audit-client-secret-development))
+      GATEWAY_HOST: prometheus-staging.service.cf.internal
+
 - name: tic-smoke-tests-development
   plan:
   - in_parallel:
@@ -300,7 +316,7 @@ jobs:
         path: /bin/bash
         args:
         - -euxc
-        - | 
+        - |
           bosh run-errand smoke-tests
   on_success:
     put: slack
@@ -458,6 +474,22 @@ jobs:
       GATEWAY_HOST: prometheus-staging.service.cf.internal
       WHITELIST: ((uaa-audit-whitelist-staging))
 
+- name: uaa-monitor-account-creation-staging
+  plan:
+  - in_parallel:
+    - get: cf-deployment
+    - get: cf-manifests
+      passed: [deploy-cf-staging]
+    - get: hourly-timer
+      trigger: true
+  - task: uaa-monitor-account-creation
+    file: cf-manifests/ci/uaa-monitor-account-creation.yml
+    params:
+      UAA_URL: ((uaa-url-staging))
+      UAA_CLIENT_ID: ((uaa-audit-client-id-staging))
+      UAA_CLIENT_SECRET: ((uaa-audit-client-secret-staging))
+      GATEWAY_HOST: prometheus-staging.service.cf.internal
+
 - name: tic-smoke-tests-staging
   plan:
   - in_parallel:
@@ -502,7 +534,7 @@ jobs:
   - in_parallel:
     - get: terraform-templates
       resource: terraform-config
-    
+
       trigger: true
       passed: [terraform-apply-development]
     - get: pipeline-tasks
@@ -844,6 +876,22 @@ jobs:
       GATEWAY_HOST: prometheus-production.service.cf.internal
       WHITELIST: ((uaa-audit-whitelist-production))
 
+- name: uaa-monitor-account-creation-production
+  plan:
+  - in_parallel:
+    - get: cf-deployment
+    - get: cf-manifests
+      passed: [deploy-cf-production]
+    - get: hourly-timer
+      trigger: true
+  - task: uaa-monitor-account-creation
+    file: cf-manifests/ci/uaa-monitor-account-creation.yml
+    params:
+      UAA_URL: ((uaa-url-production))
+      UAA_CLIENT_ID: ((uaa-audit-client-id-production))
+      UAA_CLIENT_SECRET: ((uaa-audit-client-secret-production))
+      GATEWAY_HOST: prometheus-production.service.cf.internal
+
 - name: tic-smoke-tests-production
   plan:
   - in_parallel:
@@ -886,7 +934,7 @@ jobs:
   - in_parallel:
     - get: terraform-templates
       resource: terraform-config
-    
+
       passed: [acceptance-tests-staging]
       trigger: true
     - get: pipeline-tasks
@@ -919,7 +967,7 @@ jobs:
   - in_parallel:
     - get: terraform-templates
       resource: terraform-config
-    
+
       passed: [terraform-plan-production]
     - get: pipeline-tasks
   - task: terraform-apply
@@ -1097,6 +1145,11 @@ resources:
   source:
     interval: 10m
 
+- name: hourly-timer
+  type: time
+  source:
+    interval: 1h
+
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -1121,6 +1174,7 @@ groups:
   - terraform-apply-development
   - uaa-smoke-tests-development
   - uaa-client-audit-development
+  - uaa-monitor-account-creation-development
   - tic-smoke-tests-development
   - smoke-tests-development
   - deploy-cf-staging
@@ -1128,6 +1182,7 @@ groups:
   - terraform-apply-staging
   - uaa-smoke-tests-staging
   - uaa-client-audit-staging
+  - uaa-monitor-account-creation-staging
   - tic-smoke-tests-staging
   - smoke-tests-staging
   - acceptance-tests-staging
@@ -1138,6 +1193,7 @@ groups:
   - smoke-tests-production
   - uaa-smoke-tests-production
   - uaa-client-audit-production
+  - uaa-monitor-account-creation-production
   - tic-smoke-tests-production
 - name: development
   jobs:
@@ -1146,6 +1202,7 @@ groups:
   - terraform-apply-development
   - uaa-smoke-tests-development
   - uaa-client-audit-development
+  - uaa-monitor-account-creation-development
   - tic-smoke-tests-development
   - smoke-tests-development
 - name: staging
@@ -1155,6 +1212,7 @@ groups:
   - terraform-apply-staging
   - uaa-smoke-tests-staging
   - uaa-client-audit-staging
+  - uaa-monitor-account-creation-staging
   - tic-smoke-tests-staging
   - smoke-tests-staging
   - acceptance-tests-staging
@@ -1167,4 +1225,5 @@ groups:
   - smoke-tests-production
   - uaa-smoke-tests-production
   - uaa-client-audit-production
+  - uaa-monitor-account-creation-production
   - tic-smoke-tests-production

--- a/ci/uaa-monitor-account-creation.sh
+++ b/ci/uaa-monitor-account-creation.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -eu
+
+
+### Set variables
+UAA_URL=$(echo "${UAA_URL}" | sed 's/\/$//')
+
+ACCESS_TOKEN=$(curl \
+  -s -u "${UAA_CLIENT_ID}:${UAA_CLIENT_SECRET}" \
+  "${UAA_URL}/oauth/token" -d "grant_type=client_credentials" \
+  | jq -r ".access_token")
+
+
+### Utils
+get_past_days_epoch() {
+  local days=${1:-1}
+  local result=$(date -d "-$days days" "+%s")
+
+  echo $result
+}
+
+uaacurl() {
+  curl -s -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "Accept: application/json" "${UAA_URL}$@"
+}
+
+uaa_get_page_descending() {
+  local path=$1
+  local start_index=${2:-1}
+  page=$(uaacurl -Gs "${UAA_URL}${path}?sortOrder=descending&startIndex=${start_index}")
+
+  echo $page
+}
+
+count_users_created_past_week() {
+  local days_back=${1:-7}
+  local selector=".resources"
+
+  last_week=$(get_past_days_epoch $days_back)
+  page=$(uaa_get_page_descending "/Users")
+  results=$(echo -n "${page}" | jq "${selector}")
+  user_count=$(echo $results | \
+    jq "map(.meta.created|split(\".\")|.[0]|strptime(\"%Y-%m-%dT%H:%M:%S\")|mktime|select(.>$last_week))|length")
+
+  echo ${user_count}
+}
+
+metrics=$(mktemp)
+value=$(count_users_created_past_week)
+cat >> "${metrics}" <<EOF
+uaa_monitor_account_creation ${value}
+EOF
+
+uaa_url=$(echo "${UAA_URL}" | sed 's/https:\/\///')
+curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/uaa_monitor_account_creation/uaa_url/${uaa_url}"
+curl --data-binary @${metrics} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/uaa_monitor_account_creation/uaa_url/${uaa_url}"

--- a/ci/uaa-monitor-account-creation.sh
+++ b/ci/uaa-monitor-account-creation.sh
@@ -32,8 +32,9 @@ uaa_get_page_descending() {
   echo $page
 }
 
-count_users_created_past_week() {
-  local days_back=${1:-7}
+count_users_created_recently() {
+  # Counts the number of users created in the past four days
+  local days_back=${1:-4}
   local selector=".resources"
 
   last_week=$(get_past_days_epoch $days_back)
@@ -46,7 +47,7 @@ count_users_created_past_week() {
 }
 
 metrics=$(mktemp)
-value=$(count_users_created_past_week)
+value=$(count_users_created_recently)
 cat >> "${metrics}" <<EOF
 uaa_monitor_account_creation ${value}
 EOF

--- a/ci/uaa-monitor-account-creation.yml
+++ b/ci/uaa-monitor-account-creation.yml
@@ -1,0 +1,13 @@
+---
+  platform: linux
+  image_resource:
+    type: docker-image
+    source:
+      repository: 18fgsa/concourse-task
+
+  inputs:
+  - name: cf-manifests
+  - name: cf-deployment
+
+  run:
+    path: cf-manifests/ci/uaa-monitor-account-creation.sh


### PR DESCRIPTION
Requires https://github.com/cloud-gov/cg-deploy-prometheus/pull/136 to function

## Changes proposed in this pull request:
- Add a new task to query uaa users and count the number of new users in the past ~week~ four days (for three day weekends)
  - Note: only requests the first 100 most recently created users since lately we've only averaged ~15/week and our threshold is `> 50` users.
- Job runs the `uaa-monitor-account-creation.sh` script hourly 
- Updates the `uaa-client-audit` authorities to have `scim.read` access so we do not need to add a new client to UAA

## security considerations
- none
