### PR TITLE
Setting correct CA vaules in rep containers to remove unsed credhub ca

### DIFF
--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -45,3 +45,9 @@
   value:
     - ((diego_instance_identity_ca.ca))
     - ((uaa_ssl.ca))
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates
+  value:
+    - ((diego_instance_identity_ca.ca))
+    - ((uaa_ssl.ca))


### PR DESCRIPTION
## Changes proposed in this pull request:
- In rep - remove the credhub ca value from containers as it's not needed/used

## security considerations
n/a
