### PR TITLE
remove k8s stuff from dev deployment

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -125,14 +125,6 @@
     secret: ((kibana-client-secret))
 
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/kubernetes-client?
-  value:
-    override: true
-    authorized-grant-types: client_credentials
-    authorities: cloud_controller.global_auditor
-    secret: ((kubernetes-client-secret))
-
-- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/dashboard?
   value:
     override: true

--- a/bosh/opsfiles/k8s-client.yml
+++ b/bosh/opsfiles/k8s-client.yml
@@ -1,0 +1,9 @@
+---
+# Split the k8s-related clients out from the shared clients file so we can remove them one environment at a time by removing this opsfile.
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/kubernetes-client?
+  value:
+    override: true
+    authorized-grant-types: client_credentials
+    authorities: cloud_controller.global_auditor
+    secret: ((kubernetes-client-secret))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -41,7 +41,6 @@ jobs:
       - cf-deployment/operations/enable-service-discovery.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml
-      - cf-manifests/bosh/opsfiles/kubernetes-dns.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/users.yml
       - cf-manifests/bosh/opsfiles/secureproxy.yml
@@ -406,6 +405,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml
       - cf-manifests/bosh/opsfiles/kubernetes-dns.yml
+      - cf-manifests/bosh/opsfiles/k8s-client.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/users.yml
       - cf-manifests/bosh/opsfiles/secureproxy.yml
@@ -791,6 +791,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml
       - cf-manifests/bosh/opsfiles/kubernetes-dns.yml
+      - cf-manifests/bosh/opsfiles/k8s-client.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/users.yml
       - cf-manifests/bosh/opsfiles/secureproxy.yml


### PR DESCRIPTION
Our roadmap has this switch starting on the 22nd, so don't merge this yet!

## Changes proposed in this pull request:
- Removes kubernetes client in dev deployment. I have a vague sense that this might not actually remove the user, but simply stop making sure it's there. I can't find anything to support that looking at the UAA docs, though, so I might be making things up. We should check on this afterwards
- Removes kubernetes DNS from dev deployment

Note that when we're ready to do this in staging, we'll need to make a similar change set, then again for production. We'll also need to remove the opsfiles themselves eventually. 


## security considerations
Reduces the number of credentials we have around, and also helps us get rid of k8s