### PR TITLE
remove uaa-groups opsfile for now

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -48,6 +48,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/api-defaults.yml
       - cf-manifests/bosh/opsfiles/uaa-customized.yml
       - cf-manifests/bosh/opsfiles/uaa-branding.yml
+      - cf-manifests/bosh/opsfiles/uaa-groups.yml
       - cf-manifests/bosh/opsfiles/uaa-login.yml
       - cf-manifests/bosh/opsfiles/uaa-saml.yml
       - cf-manifests/bosh/opsfiles/uaa-user.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -48,7 +48,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/api-defaults.yml
       - cf-manifests/bosh/opsfiles/uaa-customized.yml
       - cf-manifests/bosh/opsfiles/uaa-branding.yml
-      - cf-manifests/bosh/opsfiles/uaa-groups.yml
       - cf-manifests/bosh/opsfiles/uaa-login.yml
       - cf-manifests/bosh/opsfiles/uaa-saml.yml
       - cf-manifests/bosh/opsfiles/uaa-user.yml
@@ -413,7 +412,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/api-defaults.yml
       - cf-manifests/bosh/opsfiles/uaa-customized.yml
       - cf-manifests/bosh/opsfiles/uaa-branding.yml
-      - cf-manifests/bosh/opsfiles/uaa-groups.yml
       - cf-manifests/bosh/opsfiles/uaa-login.yml
       - cf-manifests/bosh/opsfiles/uaa-saml.yml
       - cf-manifests/bosh/opsfiles/uaa-user.yml
@@ -799,7 +797,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/api-defaults.yml
       - cf-manifests/bosh/opsfiles/uaa-customized.yml
       - cf-manifests/bosh/opsfiles/uaa-branding.yml
-      - cf-manifests/bosh/opsfiles/uaa-groups.yml
       - cf-manifests/bosh/opsfiles/uaa-login.yml
       - cf-manifests/bosh/opsfiles/uaa-saml.yml
       - cf-manifests/bosh/opsfiles/uaa-user.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- remove uaa-groups opsfile for now. We're picking up this change as part of k8s work and aren't sure it's ready for real yet.


## security considerations
None