### PR TITLE
Add uaa.resource authority so uaa extras can invoke introspect

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -37,7 +37,7 @@
     override: true
     scope: scim.invite,password.write
     authorized-grant-types: authorization_code,client_credentials
-    authorities: scim.read,password.write,uaa.admin
+    authorities: scim.read,password.write,uaa.admin,uaa.resource
     access-token-validity: 600
     refresh-token-validity: 259200
     redirect-uri: https://account.((system_domain))/oauth/login


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds the uaa.resource authority for the uaa_extras_app client. This is necessary for it to invoke the introspect endpoint.

## security considerations

This authority is required for introspect. 
