### PR TITLE
Terraform 13 updates

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -137,6 +137,7 @@ jobs:
   - task: terraform-plan
     file: terraform-templates/terraform/terraform-apply.yml
     params: &tf-development
+      TERRAFORM_BIN: terratest-13.6
       TERRAFORM_ACTION: plan
       TEMPLATE_SUBDIR: terraform
       STACK_NAME: cf-development
@@ -594,6 +595,7 @@ jobs:
   - task: terraform-plan
     file: terraform-templates/terraform/terraform-apply.yml
     params: &tf-staging
+      TERRAFORM_BIN: terratest-13.6
       TERRAFORM_ACTION: plan
       TEMPLATE_SUBDIR: terraform
       STACK_NAME: cf-staging
@@ -1019,6 +1021,7 @@ jobs:
   - task: terraform-plan
     file: terraform-templates/terraform/terraform-apply.yml
     params: &tf-production
+      TERRAFORM_BIN: terratest-13.6
       TERRAFORM_ACTION: plan
       TEMPLATE_SUBDIR: terraform
       STACK_NAME: cf-production

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,3 +1,9 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "0.14.0"
+    }
+  }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Terraform bin is now 13.6
- Terraform provider is updated to be used.

## security considerations
None