### PR TITLE
longer token validity for logging

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -3,6 +3,7 @@
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/logsearch_firehose_ingestor?
   value:
     override: true
+    access-token-validity: 172800
     authorized-grant-types: client_credentials
     authorities: doppler.firehose,cloud_controller.global_auditor
     secret: ((logsearch-firehose-ingestor-client-secret))
@@ -82,6 +83,7 @@
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/firehose_exporter?
   value:
     override: true
+    access-token-validity: 172800
     authorized-grant-types: client_credentials
     authorities: doppler.firehose
     secret: ((firehose-exporter-client-secret))


### PR DESCRIPTION
## Changes proposed in this pull request:
- longer token validity for logging. This is 4x the default token validity


## security considerations
reduces the likelihood of uaa downtime causing logging interruptions