### PR TITLE
Pipeline is using base terraform which is now 0.13.6

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -137,7 +137,6 @@ jobs:
   - task: terraform-plan
     file: terraform-templates/terraform/terraform-apply.yml
     params: &tf-development
-      TERRAFORM_BIN: terratest-13.6
       TERRAFORM_ACTION: plan
       TEMPLATE_SUBDIR: terraform
       STACK_NAME: cf-development
@@ -595,7 +594,6 @@ jobs:
   - task: terraform-plan
     file: terraform-templates/terraform/terraform-apply.yml
     params: &tf-staging
-      TERRAFORM_BIN: terratest-13.6
       TERRAFORM_ACTION: plan
       TEMPLATE_SUBDIR: terraform
       STACK_NAME: cf-staging
@@ -1021,7 +1019,6 @@ jobs:
   - task: terraform-plan
     file: terraform-templates/terraform/terraform-apply.yml
     params: &tf-production
-      TERRAFORM_BIN: terratest-13.6
       TERRAFORM_ACTION: plan
       TEMPLATE_SUBDIR: terraform
       STACK_NAME: cf-production


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removed Terraform bin so it can use terraform 13


## security considerations
Nada