### PR TITLE
Update pages-staging UAA config

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -155,9 +155,9 @@
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/pages-staging?
   value:
     override: true
-    scope: scim.read,openid
-    authorized-grant-types: authorization_code,client_credentials,refresh_token
-    authorities: uaa.none
+    scope: openid,scim.invite,groups.update
+    authorized-grant-types: authorization_code,client_credentials
+    authorities: scim.write,scim.read,scim.create
     access-token-validity: 600
     refresh-token-validity: 259200
     name: Pages - Staging


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updates scopes and authorities for supporting invites and associated logic for pages-staging uaa client

## security considerations
- Ensure scopes and authorities make sense and are least-privilege.

## Also
It is not urgent, but would like to remove the `admin-pages-staging` uaa client as well, but not sure where to do that.
