### PR TITLE
Added bionic ops file

### DIFF
--- a/bosh/opsfiles/use-bionic.yml
+++ b/bosh/opsfiles/use-bionic.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /stemcells/alias=default/os
+  value: bionic


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adding ops file to be used to override cf-deployment default of xenial stemcell

## security considerations
Moving to bionic keeps cloud.gov current and reduces CVEs
