### PR TITLE
missing ubuntu

### DIFF
--- a/bosh/opsfiles/use-bionic.yml
+++ b/bosh/opsfiles/use-bionic.yml
@@ -1,3 +1,3 @@
 - type: replace
   path: /stemcells/alias=default/os
-  value: bionic
+  value: ubunut-bionic


### PR DESCRIPTION
## Changes proposed in this pull request:
- missing `ubuntu` in stemcell name

## security considerations
Moving to bionic keeps the deployment updated and helps close CVEs
