### PR TITLE
Add smtp to pages-staging and remove from staging

### DIFF
--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -211,3 +211,42 @@ resource "cloudfoundry_space" "uaa-extras" {
     cloudfoundry_asg.dns.id,
   ]
 }
+
+# Federalist/Pages
+
+resource "cloudfoundry_org" "gsa-18f-federalist" {
+  name  = "gsa-18f-federalist"
+}
+
+resource "cloudfoundry_space" "pages-staging" {
+  name = "pages-staging"
+  org  = cloudfoundry_org.gsa-18f-federalist.id
+  asgs = [
+    cloudfoundry_asg.public_networks.id,
+    cloudfoundry_asg.trusted_local_networks.id,
+    cloudfoundry_asg.public_networks.id,
+    cloudfoundry_asg.dns.id,
+    cloudfoundry_asg.smtp.id,
+  ]
+  staging_asgs = [
+    cloudfoundry_asg.trusted_local_networks.id,
+    cloudfoundry_asg.public_networks.id,
+    cloudfoundry_asg.dns.id,
+  ]
+}
+
+resource "cloudfoundry_space" "staging" {
+  name = "staging"
+  org  = cloudfoundry_org.gsa-18f-federalist.id
+  asgs = [
+    cloudfoundry_asg.public_networks.id,
+    cloudfoundry_asg.trusted_local_networks.id,
+    cloudfoundry_asg.public_networks.id,
+    cloudfoundry_asg.dns.id,
+  ]
+  staging_asgs = [
+    cloudfoundry_asg.trusted_local_networks.id,
+    cloudfoundry_asg.public_networks.id,
+    cloudfoundry_asg.dns.id,
+  ]
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Closes https://github.com/cloud-gov/cg-provision/issues/853
- Adds SMTP asg to pages-staging space to support notifications and auth
- Removes SMTP asg from federalist staging since app will continue to use Github auth

## security considerations
- Allow access to SMTP network for pages staging environment
- Removes access to SMTP network from federalist space not needing email functionality
