### PR TITLE
[DRAFT] Ops file for CORS

### DIFF
--- a/bosh/opsfiles/uaa-cors.yml
+++ b/bosh/opsfiles/uaa-cors.yml
@@ -1,0 +1,51 @@
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/cors?
+  value:
+    default:
+      allowed:
+        headers:
+        - Accept
+        - Authorization
+        - Accept-Language
+        - Content-Type
+        - Content-Language
+        - If-Match
+        - X-Requested-With
+        - X-Identity-Zone-Id
+        - X-Identity-Zone-Subdomain
+        origin:
+        - ^cloud.gov$
+        - ^.*\.cloud.gov$
+        - ^localhost$
+        - ^.*\.localhost$
+        methods:
+        - GET
+        - PUT
+        - POST
+        - DELETE
+        - OPTIONS
+        credentials: true
+      max_age: 10
+    xhr:
+      allowed:
+        headers:
+        - Accept
+        - Authorization
+        - Accept-Language
+        - Content-Type
+        - Content-Language
+        - If-Match
+        - X-Requested-With
+        - X-Identity-Zone-Id
+        - X-Identity-Zone-Subdomain
+        origin:
+        - ^cloud.gov$
+        - ^.*\.cloud.gov$
+        - ^localhost$
+        - ^.*\.localhost$
+        methods:
+        - GET
+        - POST
+        - OPTIONS
+        credentials: true
+      max_age: 10


### PR DESCRIPTION
## Changes proposed in this pull request:
- This will turn on CORS filters for UAA
- Confirmed this won't break usage of gsa saml and cloud.gov idp
- Tested in dev and staging by hand and confirmed with new zap scans.
- Only thing I would be careful is it might break saml for others. If it does, you need to add that agency's url to origin
## security considerations
This is fixing a finding