### PR TITLE
Add duplicate ASGs for public networks and dns to apply individually

### DIFF
--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -172,6 +172,55 @@ resource "cloudfoundry_asg" "trusted_local_networks" {
 
 }
 
+# New trusted networks asg to apply to spaces individually, not globally.
+
+resource "cloudfoundry_asg" "trusted_local_networks_egress" {
+  name = "trusted_local_networks_egress"
+
+  # RDS access for postgres, mysql, mssql, oracle
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to RDS"
+    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
+    ports       = "5432,3306,1433,1521"
+  }
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to RDS"
+    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
+    ports       = "5432,3306,1433,1521"
+  }
+
+  # Elasticache access
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to Elasticache"
+    destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
+    ports       = "6379"
+  }
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to Elasticache"
+    destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
+    ports       = "6379"
+  }
+
+  # Elastisearch access
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS Elasticsearch"
+    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
+    ports       = "443"
+  }
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS Elasticsearch"
+    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
+    ports       = "443"
+  }
+
+}
+
 resource "cloudfoundry_asg" "brokers" {
   name = "brokers"
   rule {

--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -60,8 +60,57 @@ resource "cloudfoundry_asg" "public_networks" {
   }
 }
 
+# New public_networks asg to apply to spaces individually, not globally.
+
+resource "cloudfoundry_asg" "public_networks_egress" {
+  name = "public_networks_egress"
+
+  rule {
+    protocol    = "all"
+    destination = "0.0.0.0-9.255.255.255"
+  }
+
+  rule {
+    protocol    = "all"
+    destination = "11.0.0.0-169.253.255.255"
+  }
+
+  rule {
+    protocol    = "all"
+    destination = "169.255.0.0-172.15.255.255"
+  }
+
+  rule {
+    protocol    = "all"
+    destination = "172.32.0.0-192.167.255.255"
+  }
+
+  rule {
+    protocol    = "all"
+    destination = "192.169.0.0-255.255.255.255"
+  }
+}
+
 resource "cloudfoundry_asg" "dns" {
   name = "dns"
+
+  rule {
+    protocol    = "tcp"
+    ports       = "53"
+    destination = "0.0.0.0/0"
+  }
+
+  rule {
+    protocol    = "udp"
+    ports       = "53"
+    destination = "0.0.0.0/0"
+  }
+}
+
+# New dns asg to apply to spaces individually, not globally.
+
+resource "cloudfoundry_asg" "dns_egress" {
+  name = "dns_egress"
 
   rule {
     protocol    = "tcp"


### PR DESCRIPTION
## Changes proposed in this pull request:
### Supports the work in #565

- [x] Add duplicate ASGs for dns and public_networks to be applied to each space individually

## security considerations
None
