### PR TITLE
baseline 3 phase ops file to enable TLS thru secureproxy

### DIFF
--- a/bosh/opsfiles/secureproxy-tls-phase1.yml
+++ b/bosh/opsfiles/secureproxy-tls-phase1.yml
@@ -1,0 +1,23 @@
+# For phase 1 this enables SSL on the gorouter while leaving HTTP still running
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/enable_ssl?
+  value: true
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/tls_port?
+  value: 8443
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/tls_pem?
+  value:
+    - cert_chain: "((router_ssl.certificate))"
+      private_key: "((router_ssl.private_key))"
+- type: replace
+  path: /variables/-
+  value:
+    name: router_ssl
+    type: certificate
+    options:
+      ca: /master-bosh-ca
+      common_name: routerSSL
+      alternative_names:
+      - "((system_domain))"
+      - "*.((system_domain))"

--- a/bosh/opsfiles/secureproxy-tls-phase2.yml
+++ b/bosh/opsfiles/secureproxy-tls-phase2.yml
@@ -1,0 +1,16 @@
+# For phase 2 we enable front-end of secureproxy to accept HTTPS and go back out to gorouter via HTTPS
+- type: replace
+  path: /instance_groups/name=router/jobs/name=secureproxy/properties/secureproxy/https_listen_port?
+  value: 443
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=secureproxy/properties/secureproxy/https_proxy_port?
+  value: 8443
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=secureproxy/properties/secureproxy/tls_cert?
+  value: ((router_ssl.certificate))
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=secureproxy/properties/secureproxy/tls_key?
+  value: ((router_ssl.private_key))

--- a/bosh/opsfiles/secureproxy-tls-phase3.yml
+++ b/bosh/opsfiles/secureproxy-tls-phase3.yml
@@ -1,0 +1,4 @@
+# For phase 3 - turn off HTTP on the gorouter
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/disable_http?
+  value: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- 3 ops files (not defined in pipeline yet) to phase in TLS through secureproxy once secureproxy release is cut

## security considerations
Once all three phases are deployed on the new secureproxy, secureproxy will support TLS straight through to the gorouter