### PR TITLE
Update global running asg to just dns

### DIFF
--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -242,6 +242,12 @@ resource "cloudfoundry_asg" "smtp" {
   }
 }
 
+# Default global running ASG
+resource "cloudfoundry_default_asg" "running" {
+    name = "running"
+    asgs = [ cloudfoundry_asg.dns.id ]
+}
+
 resource "cloudfoundry_org_quota" "default-tts" {
   name                     = "default-tts"
   allow_paid_service_plans = true


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update the default running ASG to just be DNS
- This should remove the running trusted_local_networks and public_networks asg applied to all spaces

## security considerations
Will improve egress control for tenant apps
