### PR TITLE
manual bump of uaa to 75.11.0 for log4j

### DIFF
--- a/bosh/opsfiles/uaa-customized.yml
+++ b/bosh/opsfiles/uaa-customized.yml
@@ -9,3 +9,14 @@
   value:
     name: uaa-customized
     release: uaa-customized
+
+# Added 12/13/2021 to patch log4j in uaa release
+
+- path: /releases/-
+  release: uaa
+  type: replace
+  value:
+    name: uaa
+    sha1: 6e77262f553fa17a6c103282a460f7de9c56906a
+    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/uaa-75.11.0-ubuntu-bionic-1.41-20211211-022928-533874153-20211211022932.tgz
+    version: 75.11.0


### PR DESCRIPTION
## Changes proposed in this pull request:
- Manually bump uaa instead of waiting for cf-deployment 

## security considerations
Close gap with log4j
