### PR TITLE
adjusting secure service ops to not overwrite RDS certs

### DIFF
--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -41,7 +41,7 @@
   path: /variables/name=uaa_clients_cc_service_key_client_secret
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs/-
   value:
     - ((diego_instance_identity_ca.ca))
     - ((uaa_ssl.ca))


### PR DESCRIPTION
## Changes proposed in this pull request:
-change `disable-secure-service-credentials.yml` ops file to be add-on and not replace

## security considerations
Keeping updated CA certs in app containers allow easy of use of TLS amount the CG services 
