### PR TITLE
Fix RDS cert order and pipeline ops file order

### DIFF
--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -42,7 +42,7 @@
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs/-
-  value: |-
+  value:
     - ((diego_instance_identity_ca.ca))
     - ((uaa_ssl.ca))
 

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -41,7 +41,7 @@
   path: /variables/name=uaa_clients_cc_service_key_client_secret
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs/-
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
   value:
     - ((diego_instance_identity_ca.ca))
     - ((uaa_ssl.ca))

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -42,7 +42,7 @@
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs/-
-  value:
+  value: |-
     - ((diego_instance_identity_ca.ca))
     - ((uaa_ssl.ca))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -61,10 +61,10 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml
-      - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-development.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
 #remove once cf-deployment catches up - 12/13/21
@@ -478,10 +478,10 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml
-      - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
 #remove once cf-deployment catches up - 12/13/21
@@ -922,12 +922,12 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml
-      - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/scaling-production.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
 #remove once cf-deployment catches up - 12/13/21
       - cf-manifests/bosh/opsfiles/temp-buildpack.yml
       vars_files:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixed order of CA certs for RDS and ops file array order in pipeline

## security considerations
Allows the RDS CA certs to be installed as trusted CAs in app containers
