### PR TITLE
stop creating volume isolation segment

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -81,8 +81,6 @@ jobs:
       PLATFORM_ISOLATION_SEGMENT: ((platform-isolation-segment-development))
       PLATFORM_ORGANIZATION: ((platform-organization-development))
       PLATFORM_SPACE: ((platform-space-development))
-      VOLUME_ISOLATION_SEGMENT: ((volume-isolation-segment-development))
-      VOLUME_TARGETS: ((volume-targets-development))
 
   - task: enable-cf-features
     file: cf-manifests/ci/enable-cf-features.yml
@@ -499,8 +497,6 @@ jobs:
       PLATFORM_ISOLATION_SEGMENT: ((platform-isolation-segment-staging))
       PLATFORM_ORGANIZATION: ((platform-organization-staging))
       PLATFORM_SPACE: ((platform-space-staging))
-      VOLUME_ISOLATION_SEGMENT: ((volume-isolation-segment-staging))
-      VOLUME_TARGETS: ((volume-targets-staging))
 
   - task: enable-cf-features
     file: cf-manifests/ci/enable-cf-features.yml
@@ -988,8 +984,6 @@ jobs:
       PLATFORM_ISOLATION_SEGMENT: ((platform-isolation-segment-production))
       PLATFORM_ORGANIZATION: ((platform-organization-production))
       PLATFORM_SPACE: ((platform-space-production))
-      VOLUME_ISOLATION_SEGMENT: ((volume-isolation-segment-production))
-      VOLUME_TARGETS: ((volume-targets-production))
 
   - task: enable-cf-features
     file: cf-manifests/ci/enable-cf-features.yml

--- a/ci/update-isolation-segments.sh
+++ b/ci/update-isolation-segments.sh
@@ -10,16 +10,3 @@ cf target -o "${PLATFORM_ORGANIZATION}"
 cf create-isolation-segment "${PLATFORM_ISOLATION_SEGMENT}"
 cf enable-org-isolation "${PLATFORM_ORGANIZATION}" "${PLATFORM_ISOLATION_SEGMENT}"
 cf set-space-isolation-segment "${PLATFORM_SPACE}" "${PLATFORM_ISOLATION_SEGMENT}"
-
-# Create isolation segment for volume-enabled applications that want to use volume services
-# VOLUME_TARGETS should be something like "org:space1,space2 org1:space3"
-cf create-isolation-segment "${VOLUME_ISOLATION_SEGMENT}"
-for i in ${VOLUME_TARGETS} ; do
-  org="$(echo $i | awk -F: '{print $1}')"
-  spaces="$(echo $i | awk -F: '{print $2}' | sed 's/,/ /g')"
-  cf target -o "${org}"
-  cf enable-org-isolation "${org}" "${VOLUME_ISOLATION_SEGMENT}"
-  for space in ${spaces} ; do
-    cf set-space-isolation-segment "${space}" "${VOLUME_ISOLATION_SEGMENT}"
-  done
-done


### PR DESCRIPTION


## Changes proposed in this pull request:
- We don't use the volume isolation segment anymore. Remove it to reduce chance of confusion and reduce number of variables needed to create a new foundation


## security considerations
None