### PR TITLE
only fetch tcp router group when there are tcp albs

### DIFF
--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -361,10 +361,16 @@ resource "cloudfoundry_space" "email" {
 
 data "cloudfoundry_router_group" "tcp_router_group" {
   name = "default-tcp" 
+  depends_on = [
+    data.terraform_remote_state.iaas.outputs.tcp_lb_dns_names
+  ]
 }
 
 resource "cloudfoundry_isolation_segment" "tcp" {
   name = "tcp"
+  depends_on = [
+    data.terraform_remote_state.iaas.outputs.tcp_lb_dns_names
+  ]
 }
 
 resource "cloudfoundry_isolation_segment_entitlement" "tcp" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- only fetch tcp router group when there are tcp albs. Note that this isn't a true dependency; it's more like a hint at intent, but I think it's good enough for now
-
-

## security considerations
None