### PR TITLE
commenting out temp buildpack from pipeline

### DIFF
--- a/bosh/opsfiles/temp-buildpack.yml
+++ b/bosh/opsfiles/temp-buildpack.yml
@@ -1,4 +1,5 @@
 # Added 12/17/21  to bump php and java buildpacks to cover log4j until cf-deployment catches up
+# Removed 03/02/22 from pipeline ci file since cf-deployment has caught up
 
 - type: replace
   path: /releases/name=java-buildpack

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -67,8 +67,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
-#remove once cf-deployment catches up - 12/13/21
-      - cf-manifests/bosh/opsfiles/temp-buildpack.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -475,8 +473,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
-#remove once cf-deployment catches up - 12/13/21
-      - cf-manifests/bosh/opsfiles/temp-buildpack.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -910,8 +906,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
-#remove once cf-deployment catches up - 12/13/21
-      - cf-manifests/bosh/opsfiles/temp-buildpack.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
Signed-off-by: Chris McGowan <christopher.r.mcgowan@gsa.gov>

## Changes proposed in this pull request:
- Commenting out temp-buildpack ops file - leave file for future use if needed
- Remove ops file from pipeline for future deploys

## security considerations
Moving back to inline cf-deployment now that it's getting updated again
