### PR TITLE
Allow pages UAA client to invite users

### DIFF
--- a/bosh/opsfiles/pages-clients-dev.yml
+++ b/bosh/opsfiles/pages-clients-dev.yml
@@ -11,7 +11,7 @@
     override: true
     scope: openid,scim.invite
     authorized-grant-types: authorization_code,client_credentials
-    authorities: groups.update,scim.read
+    authorities: groups.update,scim.read,scim.invite
     access-token-validity: 600
     refresh-token-validity: 259200
     name: Pages - Dev

--- a/bosh/opsfiles/pages-clients-production.yml
+++ b/bosh/opsfiles/pages-clients-production.yml
@@ -11,7 +11,7 @@
     override: true
     scope: openid,scim.invite
     authorized-grant-types: authorization_code,client_credentials
-    authorities: groups.update,scim.read
+    authorities: groups.update,scim.read,scim.invite
     access-token-validity: 600
     refresh-token-validity: 259200
     name: Pages - Production

--- a/bosh/opsfiles/pages-clients-staging.yml
+++ b/bosh/opsfiles/pages-clients-staging.yml
@@ -11,7 +11,7 @@
     override: true
     scope: openid,scim.invite
     authorized-grant-types: authorization_code,client_credentials
-    authorities: groups.update,scim.read
+    authorities: groups.update,scim.read,scim.invite
     access-token-validity: 600
     refresh-token-validity: 259200
     name: Pages - Staging


### PR DESCRIPTION
## Changes proposed in this pull request:
- Support 18f/federalist#3845
- Allow the UAA client to invite users to support self-migration from Github auth to UAA auth

## security considerations
Pages UAA client now allowed to invite users
