### PR TITLE
Add specific dashboard tic tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -267,60 +267,7 @@ jobs:
     params:
       CI: true
       API_HOSTNAME: api.dev.us-gov-west-1.aws-us-gov.cloud.gov
-      BOSH_ENVIRONMENT: ((development-bosh-target))
-      BOSH_CLIENT: ((development-bosh-username))
-      BOSH_CLIENT_SECRET: ((development-bosh-password))
-      BOSH_DEPLOYMENT_NAME: cf-development
-      BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      RESTRICTED_DOMAIN: ((tic-test-restricted-domain))
-      UNRESTRICTED_DOMAIN: ((tic-test-unrestricted-domain))
-      SOURCE_ADDRESS_ALLOWED: ((tic-test-source-address-allowed))
-      SOURCE_ADDRESS_FORBIDDEN: ((tic-test-source-address-forbidden))
-      PROXY_ADDRESS_ALLOWED: ((tic-test-proxy-address-allowed))
-      PROXY_ADDRESS_FORBIDDEN: ((tic-test-proxy-address-forbidden))
-      TIC_SECRET_ALLOWED: ((tic-secret-development))
-      TIC_SECRET_FORBIDDEN: ((tic-test-tic-secret-forbidden))
-      TIC_PROTOCAL: https
-      GOROUTER_PORT: 443
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: TIC Smoke Tests for CF on development FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: tic-smoke-tests-development-dashboard
-  plan:
-  - in_parallel:
-    - get: master-bosh-root-cert
-      passed: [deploy-cf-development]
-      trigger: true
-    - get: cf-deployment-development
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-deployment
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-stemcell-bionic
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-manifests
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: uaa-customized-release
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cg-s3-secureproxy-release
-      trigger: true
-      passed: [deploy-cf-development]
-  - task: smoke-tests
-    file: cf-manifests/ci/tic-smoke-tests.yml
-    params:
-      CI: true
-      API_HOSTNAME: dashboard.dev.us-gov-west-1.aws-us-gov.cloud.gov
+      DASHBOARD_HOSTNAME: dashboard.dev.us-gov-west-1.aws-us-gov.cloud.gov
       BOSH_ENVIRONMENT: ((development-bosh-target))
       BOSH_CLIENT: ((development-bosh-username))
       BOSH_CLIENT_SECRET: ((development-bosh-password))
@@ -656,6 +603,7 @@ jobs:
     params:
       CI: true
       API_HOSTNAME: api.fr-stage.cloud.gov
+      DASHBOARD_HOSTNAME: dashboard.fr-stage.cloud.gov
       BOSH_ENVIRONMENT: ((staging-bosh-target))
       BOSH_CLIENT: ((staging-bosh-username))
       BOSH_CLIENT_SECRET: ((staging-bosh-password))
@@ -1125,6 +1073,7 @@ jobs:
     params:
       CI: true
       API_HOSTNAME: api.fr.cloud.gov
+      DASHBOARD_HOSTNAME: dashboard.fr.cloud.gov
       BOSH_ENVIRONMENT: ((production-bosh-target))
       BOSH_CLIENT: ((production-bosh-username))
       BOSH_CLIENT_SECRET: ((production-bosh-password))
@@ -1450,7 +1399,6 @@ groups:
   - uaa-client-auditing-development
   - uaa-monitor-account-creation-development
   - tic-smoke-tests-development
-  - tic-smoke-tests-development-dashboard
   - smoke-tests-development
   - test-space-egress-development
   - deploy-cf-staging
@@ -1482,7 +1430,6 @@ groups:
   - uaa-client-auditing-development
   - uaa-monitor-account-creation-development
   - tic-smoke-tests-development
-  - tic-smoke-tests-development-dashboard
   - smoke-tests-development
   - test-space-egress-development
 - name: staging

--- a/ci/tic-smoke-tests.sh
+++ b/ci/tic-smoke-tests.sh
@@ -16,18 +16,20 @@ gorouter_ip=$(
     | head -n 1
 )
 
-@test "restricted user | address allowed" {
+@test "restricted user from allowed address can reach API" {
   resp=$(curl -s -k \
     ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${SOURCE_ADDRESS_ALLOWED}" \
     -w '\n%{http_code}')
+  # 401 because our Authorization header is bogus
   [ $(echo "${resp}" | tail -n 1) = "401" ]
+  # validate the code in the body to make sure it looks like we really reached CAPI
   [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "10002" ]
 }
 
-@test "restricted user | address forbidden" {
+@test "restricted user from unallowed is blocked by secureproxy when requesting API" {
   resp=$(curl -s -k \
     ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
     -H "Host: ${API_HOSTNAME}" \
@@ -38,7 +40,7 @@ gorouter_ip=$(
   [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
 }
 
-@test "restricted user | secret allowed | proxy allowed | address allowed (X-Client-IP)" {
+@test "x-client-ip is trusted when x-forwarded-for is a trusted proxy, allowing restricted user to access API from allowed address" {
   resp=$(curl -s -k \
     ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
     -H "Host: ${API_HOSTNAME}" \
@@ -47,11 +49,13 @@ gorouter_ip=$(
     -H "X-TIC-Secret: ${TIC_SECRET_ALLOWED}" \
     -H "X-Client-IP: ${SOURCE_ADDRESS_ALLOWED}" \
     -w '\n%{http_code}')
+  # 401 because our Authorization header is bogus
   [ $(echo "${resp}" | tail -n 1) = "401" ]
+  # validate the code in the body to make sure it looks like we really reached CAPI
   [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "10002" ]
 }
 
-@test "restricted user | secret allowed | proxy forbidden | address allowed (X-Client-IP)" {
+@test "x-client-ip is not trusted when x-forwarded-for is untrusted, disallowing restricted user from accessing API with allowed address in x-client-ip" {
   resp=$(curl -s -k \
     ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
     -H "Host: ${API_HOSTNAME}" \
@@ -64,7 +68,7 @@ gorouter_ip=$(
   [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
 }
 
-@test "restricted user | secret forbidden | proxy allowed | address allowed (X-Client-IP)" {
+@test "x-client-ip is not trusted when x-tic-secret is invalid, disallowing restricted user from accessing API with allowed address in x-client-ip" {
   resp=$(curl -s -k \
     ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
     -H "Host: ${API_HOSTNAME}" \
@@ -77,7 +81,7 @@ gorouter_ip=$(
   [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
 }
 
-@test "restricted user | secret allowed | proxy allowed | address forbidden (X-Client-IP)" {
+@test "x-client-ip is trusted when x-tic-secret and proxy address are trusted, disallowing restricted user from accessing API with disallowed address in x-client-ip" {
   resp=$(curl -s -k \
     ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
     -H "Host: ${API_HOSTNAME}" \
@@ -90,7 +94,7 @@ gorouter_ip=$(
   [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
 }
 
-@test "restricted user | secret empty | proxy allowed | address allowed (X-Client-IP)" {
+@test "x-client-ip is not trusted when x-tic-secret is empty, disallowing restricted user from accessing API with allowed address in x-client-ip" {
   resp=$(curl -s -k \
     ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
     -H "Host: ${API_HOSTNAME}" \
@@ -103,13 +107,119 @@ gorouter_ip=$(
   [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
 }
 
-@test "unrestricted user" {
+@test "unrestricted user can access API from forbidden address" {
   resp=$(curl -s -k \
     ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${unrestricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${SOURCE_ADDRESS_FORBIDDEN}" \
     -w '\n%{http_code}')
+  # 401 because our Authorization header is bogus
   [ $(echo "${resp}" | tail -n 1) = "401" ]
+  # validate the code in the body to make sure it looks like we really reached CAPI
   [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "10002" ]
+}
+
+@test "restricted user can access the dashboard from an allowed address" {
+  resp=$(curl -s -k \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    -H "Host: ${DASHBOARD_HOSTNAME}" \
+    -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
+    -H "X-Forwarded-For: ${SOURCE_ADDRESS_ALLOWED}" \
+    -w '\n%{http_code}')
+  # 401 because our Authorization header is bogus
+  [ $(echo "${resp}" | tail -n 1) = "401" ]
+  # validate the error message in the body to make sure it looks like we really reached Stratos
+  [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "User session could not be found" ]
+}
+
+@test "restricted user cannot access the dashboard from an unallowed address" {
+  resp=$(curl -s -k \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    -H "Host: ${DASHBOARD_HOSTNAME}" \
+    -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
+    -H "X-Forwarded-For: ${SOURCE_ADDRESS_FORBIDDEN}" \
+    -w '\n%{http_code}')
+  [ $(echo "${resp}" | tail -n 1) = "403" ]
+  [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
+}
+
+@test "x-client-ip is trusted when x-forwarded-for is a trusted proxy, allowing restricted user to access dashboard from allowed address" {
+  resp=$(curl -s -k \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    -H "Host: ${DASHBOARD_HOSTNAME}" \
+    -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
+    -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
+    -H "X-TIC-Secret: ${TIC_SECRET_ALLOWED}" \
+    -H "X-Client-IP: ${SOURCE_ADDRESS_ALLOWED}" \
+    -w '\n%{http_code}')
+  # 401 because our Authorization header is bogus
+  [ $(echo "${resp}" | tail -n 1) = "401" ]
+  # validate the code in the body to make sure it looks like we really reached Stratos
+  [ $(echo "${resp}" | head -n -1 | jq -r '.error') = "User session could not be found" ]
+}
+
+@test "x-client-ip is not trusted when x-forwarded-for is untrusted, disallowing restricted user from accessing dashboard with allowed address in x-client-ip" {
+  resp=$(curl -s -k \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    -H "Host: ${DASHBOARD_HOSTNAME}" \
+    -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
+    -H "X-Forwarded-For: ${PROXY_ADDRESS_FORBIDDEN}" \
+    -H "X-TIC-Secret: ${TIC_SECRET_ALLOWED}" \
+    -H "X-Client-IP: ${SOURCE_ADDRESS_ALLOWED}" \
+    -w '\n%{http_code}')
+  [ $(echo "${resp}" | tail -n 1) = "403" ]
+  [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
+}
+
+@test "x-client-ip is not trusted when x-tic-secret is invalid, disallowing restricted user from accessing dashboard with allowed address in x-client-ip" {
+  resp=$(curl -s -k \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    -H "Host: ${DASHBOARD_HOSTNAME}" \
+    -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
+    -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
+    -H "X-TIC-Secret: ${TIC_SECRET_FORBIDDEN}" \
+    -H "X-Client-IP: ${SOURCE_ADDRESS_ALLOWED}" \
+    -w '\n%{http_code}')
+  [ $(echo "${resp}" | tail -n 1) = "403" ]
+  [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
+}
+
+@test "x-client-ip is trusted when x-tic-secret and proxy address are trusted, disallowing restricted user from accessing dashboard with disallowed address in x-client-ip" {
+  resp=$(curl -s -k \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    -H "Host: ${DASHBOARD_HOSTNAME}" \
+    -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
+    -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
+    -H "X-TIC-Secret: ${TIC_SECRET_ALLOWED}" \
+    -H "X-Client-IP: ${SOURCE_ADDRESS_FORBIDDEN}" \
+    -w '\n%{http_code}')
+  [ $(echo "${resp}" | tail -n 1) = "403" ]
+  [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
+}
+
+@test "x-client-ip is not trusted when x-tic-secret is empty, disallowing restricted user from accessing dashboard with allowed address in x-client-ip" {
+  resp=$(curl -s -k \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    -H "Host: ${DASHBOARD_HOSTNAME}" \
+    -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
+    -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
+    -H "X-TIC-Secret: " \
+    -H "X-Client-IP: ${SOURCE_ADDRESS_ALLOWED}" \
+    -w '\n%{http_code}')
+  [ $(echo "${resp}" | tail -n 1) = "403" ]
+  [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "9162" ]
+}
+
+@test "unrestricted user can access the dashboard from unallowed address" {
+  resp=$(curl -s -k \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    -H "Host: ${DASHBOARD_HOSTNAME}" \
+    -H "Authorization: $(echo '{}' | base64).$(echo ${unrestricted_payload} | base64).$(echo '{}' | base64)" \
+    -H "X-Forwarded-For: ${SOURCE_ADDRESS_FORBIDDEN}" \
+    -w '\n%{http_code}')
+  # 401 because our Authorization header is bogus
+  [ $(echo "${resp}" | tail -n 1) = "401" ]
+  # validate the error message in the body to make sure it looks like we really reached Stratos
+  [ $(echo "${resp}" | head -n -1 | jq -r '.code') = "User session could not be found" ]
 }


### PR DESCRIPTION
Stratos needs different targets and expected responses for test successes, so we need dashboard-specific tests

## Changes proposed in this pull request:
- Add specific dashboard tic tests
- Also update tests to have more human-readable names (LMK if these are worse!)
- Add comments about why specific responses are expected

## security considerations
None