### PR TITLE
require tests to pass for deployment to continue

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -563,21 +563,19 @@ jobs:
       passed: [deploy-cf-staging]
       trigger: true
     - get: cf-deployment
-      trigger: true
       passed: [deploy-cf-staging]
     - get: cf-stemcell-bionic
-      trigger: true
       passed: [deploy-cf-staging]
     - get: uaa-customized-release
-      trigger: true
       passed: [deploy-cf-staging]
     - get: cg-s3-secureproxy-release
       passed: [deploy-cf-staging]
     - get: terraform-config
+      trigger: true
       passed: [terraform-apply-staging]
-    - get: master-bosh-root-cert
     - get: pipeline-tasks
       passed: [deploy-cf-staging]
+      trigger: true
   - task: smoke-tests
     file: pipeline-tasks/uaa-smoke-tests.yml
     params:
@@ -636,13 +634,10 @@ jobs:
       passed: [deploy-cf-staging]
       trigger: true
     - get: cf-deployment
-      trigger: true
       passed: [deploy-cf-staging]
     - get: cf-stemcell-bionic
-      trigger: true
       passed: [deploy-cf-staging]
     - get: uaa-customized-release
-      trigger: true
       passed: [deploy-cf-staging]
     - get: cg-s3-secureproxy-release
       passed: [deploy-cf-staging]
@@ -881,10 +876,6 @@ jobs:
   serial_groups: [staging]
   plan:
   - in_parallel:
-    - get: common
-      resource: master-bosh-root-cert
-      trigger: true
-      passed: [deploy-cf-staging]
     - get: cf-deployment-staging
       passed: [deploy-cf-staging]
       trigger: true
@@ -892,13 +883,10 @@ jobs:
       passed: [deploy-cf-staging]
       trigger: true
     - get: cf-deployment
-      trigger: true
       passed: [deploy-cf-staging]
     - get: cf-stemcell-bionic
-      trigger: true
       passed: [deploy-cf-staging]
     - get: uaa-customized-release
-      trigger: true
       passed: [deploy-cf-staging]
     - get: cg-s3-secureproxy-release
       passed: [deploy-cf-staging]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -299,25 +299,47 @@ jobs:
   - in_parallel:
     - get: common
       resource: master-bosh-root-cert
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      passed: 
+      - tic-smoke-tests-development
+      - uaa-smoke-tests-development 
+      - test-space-egress-development
       trigger: true
     - get: cf-deployment-development
       trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      passed: 
+      - tic-smoke-tests-development
+      - uaa-smoke-tests-development 
+      - test-space-egress-development
     - get: cf-deployment
       trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      passed: 
+      - tic-smoke-tests-development
+      - uaa-smoke-tests-development 
+      - test-space-egress-development
     - get: cf-stemcell-bionic
       trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      passed: 
+      - tic-smoke-tests-development
+      - uaa-smoke-tests-development 
+      - test-space-egress-development
     - get: cf-manifests
       trigger: true
+      passed: 
+      - tic-smoke-tests-development
+      - uaa-smoke-tests-development 
+      - test-space-egress-development
     - get: uaa-customized-release
       trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      passed: 
+      - tic-smoke-tests-development
+      - uaa-smoke-tests-development 
+      - test-space-egress-development
     - get: cg-s3-secureproxy-release
       trigger: true
-      passed: [tic-smoke-tests-development,uaa-smoke-tests-development]
+      passed: 
+      - tic-smoke-tests-development
+      - uaa-smoke-tests-development 
+      - test-space-egress-development
   - task: run-errand
     attempts: 3
     params:
@@ -534,11 +556,28 @@ jobs:
 - name: uaa-smoke-tests-staging
   plan:
   - in_parallel:
-    - get: pipeline-tasks
-      passed: [deploy-cf-staging]
     - get: cf-deployment-staging
       passed: [deploy-cf-staging]
       trigger: true
+    - get: cf-manifests
+      passed: [deploy-cf-staging]
+      trigger: true
+    - get: cf-deployment
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: cf-stemcell-bionic
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: uaa-customized-release
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: cg-s3-secureproxy-release
+      passed: [deploy-cf-staging]
+    - get: terraform-config
+      passed: [terraform-apply-staging]
+    - get: master-bosh-root-cert
+    - get: pipeline-tasks
+      passed: [deploy-cf-staging]
   - task: smoke-tests
     file: pipeline-tasks/uaa-smoke-tests.yml
     params:
@@ -590,13 +629,26 @@ jobs:
 - name: tic-smoke-tests-staging
   plan:
   - in_parallel:
-    - get: cf-manifests
-      passed: [deploy-cf-staging]
     - get: cf-deployment-staging
       passed: [deploy-cf-staging]
       trigger: true
+    - get: cf-manifests
+      passed: [deploy-cf-staging]
+      trigger: true
+    - get: cf-deployment
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: cf-stemcell-bionic
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: uaa-customized-release
+      trigger: true
+      passed: [deploy-cf-staging]
     - get: cg-s3-secureproxy-release
       passed: [deploy-cf-staging]
+    - get: terraform-config
+      passed: [terraform-apply-staging]
+      trigger: true
     - get: master-bosh-root-cert
   - task: smoke-tests
     file: cf-manifests/ci/tic-smoke-tests.yml
@@ -743,27 +795,55 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment-staging
-      passed: [smoke-tests-staging]
+      passed: 
+      - tic-smoke-tests-staging
+      - uaa-smoke-tests-staging 
+      - test-space-egress-staging
+      - smoke-tests-staging
       trigger: true
     # Get resources from upstream jobs for use in production deploy
     - get: cf-manifests
-      passed: [smoke-tests-staging]
+      passed: 
+      - tic-smoke-tests-staging
+      - uaa-smoke-tests-staging 
+      - test-space-egress-staging
+      - smoke-tests-staging
       trigger: true
     - get: cf-deployment
       trigger: true
-      passed: [smoke-tests-staging]
+      passed: 
+      - tic-smoke-tests-staging
+      - uaa-smoke-tests-staging 
+      - test-space-egress-staging
+      - smoke-tests-staging
     - get: cf-stemcell-bionic
       trigger: true
-      passed: [smoke-tests-staging]
+      passed: 
+      - tic-smoke-tests-staging
+      - uaa-smoke-tests-staging 
+      - test-space-egress-staging
+      - smoke-tests-staging
     - get: uaa-customized-release
       trigger: true
-      passed: [smoke-tests-staging]
+      passed: 
+      - tic-smoke-tests-staging
+      - uaa-smoke-tests-staging 
+      - test-space-egress-staging
+      - smoke-tests-staging
     - get: cg-s3-secureproxy-release
       trigger: true
-      passed: [smoke-tests-staging]
+      passed: 
+      - tic-smoke-tests-staging
+      - uaa-smoke-tests-staging 
+      - test-space-egress-staging
+      - smoke-tests-staging
     - get: terraform-config
       trigger: true
-      passed: [smoke-tests-staging]
+      passed: 
+      - tic-smoke-tests-staging
+      - uaa-smoke-tests-staging 
+      - test-space-egress-staging
+      - smoke-tests-staging
   - task: test-config
     file: cf-manifests/ci/acceptance-tests-config.yml
     params:
@@ -801,10 +881,30 @@ jobs:
   serial_groups: [staging]
   plan:
   - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
+    - get: common
+      resource: master-bosh-root-cert
       trigger: true
       passed: [deploy-cf-staging]
+    - get: cf-deployment-staging
+      passed: [deploy-cf-staging]
+      trigger: true
+    - get: cf-manifests
+      passed: [deploy-cf-staging]
+      trigger: true
+    - get: cf-deployment
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: cf-stemcell-bionic
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: uaa-customized-release
+      trigger: true
+      passed: [deploy-cf-staging]
+    - get: cg-s3-secureproxy-release
+      passed: [deploy-cf-staging]
+    - get: terraform-config
+      passed: [terraform-apply-staging]
+      trigger: true
   - task: deploy-test-env
     file: cf-manifests/ci/test-space-egress/task-deploy-test-env.yml
     params: &test-space-egress-staging-params


### PR DESCRIPTION
## Changes proposed in this pull request:
- make all smoke tests pass before moving to acceptance tests

## security considerations
making our tests into gates means we're validating our assertions and less likely to introduce failures into production