### PR TITLE
pass broker name to create-service

### DIFF
--- a/ci/test-space-egress/deploy-env.sh
+++ b/ci/test-space-egress/deploy-env.sh
@@ -64,7 +64,7 @@ do
   cf target -o $ORG -s $space
 
   # Create the db service instance
-  cf create-service aws-rds micro-psql $space-db
+  cf create-service -b aws-rds aws-rds micro-psql $space-db
 done
 
 ## Wait for databases to create


### PR DESCRIPTION
since the cf marketplace sometimes gets messy in dev/stage, we should be explicit about what broker we want

## Changes proposed in this pull request:
- pass broker name to create-service


## security considerations
None