### PR TITLE
use the brokers actual name

### DIFF
--- a/ci/test-space-egress/deploy-env.sh
+++ b/ci/test-space-egress/deploy-env.sh
@@ -64,7 +64,7 @@ do
   cf target -o $ORG -s $space
 
   # Create the db service instance
-  cf create-service -b aws-rds aws-rds micro-psql $space-db
+  cf create-service -b aws-broker aws-rds micro-psql $space-db
 done
 
 ## Wait for databases to create


### PR DESCRIPTION
## Changes proposed in this pull request:
- use the brokers actual name - it's the aws-broker, not the aws-rds
-
-

## security considerations
None