### PR TITLE
add content-security-policy options to dev secureproxy

### DIFF
--- a/bosh/opsfiles/content-security-policy.yml
+++ b/bosh/opsfiles/content-security-policy.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=router/jobs/name=secureproxy/properties/secureproxy/csp/-
+  value:
+    enabled: ((csp-enabled))
+    report_only: ((csp-report-only))
+    report_uri: ((csp-report-uri))
+    host_patterns: ((csp-host-patterns))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -68,6 +68,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+      - cf-manifests/bosh/opsfiles/content-security-policy.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- add content-security-policy options to dev secureproxy

relies on cloud-gov/cg-secureproxy-boshrelease#63, as well as setting some variables in credhub

## security considerations
Iterates on us getting content-security-policy defaults for platform apps that don't provide them