### PR TITLE
add s3 gateway to trusted egress

### DIFF
--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -173,6 +173,21 @@ resource "cloudfoundry_asg" "trusted_local_networks" {
     ports       = "443"
   }
 
+  # S3 Gateway access
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_1
+    ports       = "443"
+  }
+  
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_2
+    ports       = "443"
+  }
+  
 }
 
 # New trusted networks asg to apply to spaces individually, not globally.
@@ -219,6 +234,21 @@ resource "cloudfoundry_asg" "trusted_local_networks_egress" {
     protocol    = "tcp"
     description = "Allow access to AWS Elasticsearch"
     destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
+    ports       = "443"
+  }
+
+  # S3 Gateway access
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_1
+    ports       = "443"
+  }
+
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_2
     ports       = "443"
   }
 

--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -92,6 +92,22 @@ resource "cloudfoundry_asg" "public_networks_egress" {
     protocol    = "all"
     destination = "192.169.0.0-255.255.255.255"
   }
+
+  rule {
+    description = "Rule for private endpoint to s3 in region"
+    protocol    = "tcp"
+    destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_az1_ip
+    ports="443"
+  }
+
+  rule{
+    description = "Rule for private endpoint to s3 in region"
+    protocol    = "tcp"
+    destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_az1_ip
+    ports="443"
+  }
+
+
 }
 
 resource "cloudfoundry_asg" "dns" {

--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -96,14 +96,14 @@ resource "cloudfoundry_asg" "public_networks_egress" {
   rule {
     description = "Rule for private endpoint to s3 in region"
     protocol    = "tcp"
-    destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_az1_ip
+    destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if1_ip
     ports="443"
   }
 
   rule{
     description = "Rule for private endpoint to s3 in region"
     protocol    = "tcp"
-    destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_az1_ip
+    destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if2_ip
     ports="443"
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds S3 private gateway to trusted egress ASGs enabling internal s3 access for clients
- Adds S3 private endpoint to public egress ASG enabling external s3 bucket access for clients. 
-

## security considerations
Clients would now be able to connect to their s3 buckets with restricted local access. 
Access controls are set by IAM policy via the service credentials, and by the gateway policy which limits use to principals and resources in the hosting account. 

resolves cloud-gov/product/issues/1775