### PR TITLE
move opsfile for TCP routers

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -544,6 +544,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/sql.yml
       - cf-manifests/bosh/opsfiles/log-levels.yml
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
+      - cf-manifests/bosh/opsfiles/tcp-cells-and-routers.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/diego-dns.yml
@@ -555,7 +556,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
-      - cf-manifests/bosh/opsfiles/tcp-cells-and-routers.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Move location of TCP routers opsfile in CI pipeline definition for staging deploy to match dev

## security considerations

None
