### PR TITLE
remove opsfile for staging that disables TCP routing

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -525,7 +525,6 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
-      - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/latest-stemcell.yml
       - cf-manifests/bosh/opsfiles/use-bionic.yml
       - cf-manifests/bosh/opsfiles/clients.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove opsfile for staging that disables TCP routing

## security considerations

TCP routing will now be enabled on staging
