### PR TITLE
Revert "s3 egress for trusted asgs"

### DIFF
--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -107,6 +107,7 @@ resource "cloudfoundry_asg" "public_networks_egress" {
     ports="443"
   }
 
+
 }
 
 resource "cloudfoundry_asg" "dns" {
@@ -187,7 +188,7 @@ resource "cloudfoundry_asg" "trusted_local_networks" {
     destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
     ports       = "443"
   }
-
+/* ready for roll out, when federalist ECR can work
   # S3 Gateway access
   rule {
     protocol    = "tcp"
@@ -202,7 +203,7 @@ resource "cloudfoundry_asg" "trusted_local_networks" {
     destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_2
     ports       = "443"
   }
-  
+  */
 }
 
 # New trusted networks asg to apply to spaces individually, not globally.
@@ -251,7 +252,7 @@ resource "cloudfoundry_asg" "trusted_local_networks_egress" {
     destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
     ports       = "443"
   }
-
+/*
   # S3 Gateway access
   rule {
     protocol    = "tcp"
@@ -266,7 +267,7 @@ resource "cloudfoundry_asg" "trusted_local_networks_egress" {
     destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_2
     ports       = "443"
   }
-
+*/
 }
 
 resource "cloudfoundry_asg" "brokers" {


### PR DESCRIPTION
## Changes proposed in this pull request:
Reverts cloud-gov/cg-deploy-cf#688
conflicts with TCP Routing changes
## security considerations
None