### PR TITLE
Capi rollback

### DIFF
--- a/bosh/opsfiles/temp_fix.yml
+++ b/bosh/opsfiles/temp_fix.yml
@@ -1,0 +1,10 @@
+# The whole purpose of this file is to be used to temp merge in certain aspects to the deployment - mainly to rollback or forward certain options until cf-deployment catches up
+
+# Rolling back CAPI from v1.134.0 to v.1.133.0 due to cpu/memory leak - see https://github.com/cloudfoundry/capi-release/issues/262
+- type: replace
+  path: /releases/name=capi
+  value:
+    name: "capi"
+    version: "1.133.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.133.0"
+    sha1: "6d54b25f19a85e4052d539e940b0545fccc9e802"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1054,6 +1054,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+      - cf-manifests/bosh/opsfiles/temp_fix.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -67,6 +67,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+      - cf-manifests/bosh/opsfiles/temp_fix.yml
       - cf-manifests/bosh/opsfiles/content-security-policy.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
@@ -553,6 +554,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+      - cf-manifests/bosh/opsfiles/temp_fix.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Roll capi back from 1.134.0 to 1.133.0 due to memory leak
- See [Github Issue
](https://github.com/cloudfoundry/capi-release/issues/262)

## security considerations
API Nodes running out of memory cause system monitoring issues
