### PR TITLE
Update UAA release version management

### DIFF
--- a/bosh/opsfiles/uaa-customized.yml
+++ b/bosh/opsfiles/uaa-customized.yml
@@ -9,11 +9,3 @@
   value:
     name: uaa-customized
     release: uaa-customized
-
-# Added 12/13/2021 to patch log4j in uaa release
-
-- type: replace
-  path: /releases/name=uaa
-  value:
-    name: uaa
-    version: latest


### PR DESCRIPTION
## Changes proposed in this pull request:

Remove opsfile modification that uses "latest" UAA release from bosh. This change is pinning us to whatever latest release of UAA we already have on our BOSH directors. It doesn't fetch the latest UAA release from any outside source. By deleting this opsfile modification, we'll now use the UAA version defined in the upstream CF deploy code: https://github.com/cloudfoundry/cf-deployment/blob/main/cf-deployment.yml#L2894-L2897

## security considerations

Making sure we keep up to date with UAA should be an improvement for security