### PR TITLE
increase number of diego cell VMs in prod to 36

### DIFF
--- a/bosh/opsfiles/scaling-production.yml
+++ b/bosh/opsfiles/scaling-production.yml
@@ -57,7 +57,7 @@
 # diego platform (platform and customer)
 - type: replace
   path: /instance_groups/name=diego-cell/instances
-  value: 33
+  value: 36
 - type: replace
   path: /instance_groups/name=diego-cell/vm_type
   value: m5.2xlarge


### PR DESCRIPTION
## Changes proposed in this pull request:

- increase number of diego cell VMs in prod to 36 to address alerts about low memory for CF cells

## security considerations

None
