### PR TITLE
fix: Add proper authority to pages client to allow member add scope on user invite

### DIFF
--- a/bosh/opsfiles/pages-clients-dev.yml
+++ b/bosh/opsfiles/pages-clients-dev.yml
@@ -11,7 +11,7 @@
     override: true
     scope: openid,scim.invite
     authorized-grant-types: authorization_code,client_credentials
-    authorities: groups.update,scim.read,scim.invite
+    authorities: groups.update,scim.read,scim.invite,scim.write
     access-token-validity: 600
     refresh-token-validity: 259200
     name: Pages - Dev

--- a/bosh/opsfiles/pages-clients-production.yml
+++ b/bosh/opsfiles/pages-clients-production.yml
@@ -11,7 +11,7 @@
     override: true
     scope: openid,scim.invite
     authorized-grant-types: authorization_code,client_credentials
-    authorities: groups.update,scim.read,scim.invite
+    authorities: groups.update,scim.read,scim.invite,scim.write
     access-token-validity: 600
     refresh-token-validity: 259200
     name: Pages - Production

--- a/bosh/opsfiles/pages-clients-staging.yml
+++ b/bosh/opsfiles/pages-clients-staging.yml
@@ -11,7 +11,7 @@
     override: true
     scope: openid,scim.invite
     authorized-grant-types: authorization_code,client_credentials
-    authorities: groups.update,scim.read,scim.invite
+    authorities: groups.update,scim.read,scim.invite,scim.write
     access-token-validity: 600
     refresh-token-validity: 259200
     name: Pages - Staging


### PR DESCRIPTION
In order to allow pages users that are org manager to add new users to their org, we need to update the authorities of the UAA pages client to allow for `scim.write` so they can add the invited users as a member to the `pages.user` group in UAA.

## Changes proposed in this pull request:
- Adds `scim.write` to pages UAA client authorities 

## security considerations
Update's pages uaa client authority to add `scim.write` scope in order to do a UAA member add to a UAA group but it is only used on authenticated requests available to org managers  and the authority is not available to user outside of the request. The token is not saved or available to the end user.
