### PR TITLE
pin uaa to 75.23 while we fix uaa-customized

### DIFF
--- a/bosh/opsfiles/uaa-customized.yml
+++ b/bosh/opsfiles/uaa-customized.yml
@@ -9,3 +9,11 @@
   value:
     name: uaa-customized
     release: uaa-customized
+
+- type: replace
+  path: /releases/name=uaa
+  value:
+    name: uaa
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.23.0
+    version: 75.23.0
+    sha1: 328493d41fdfb2728ee17f8e3fcad1b7296a702f


### PR DESCRIPTION
## Changes proposed in this pull request:
- pin uaa to `75.23` since `76` adds CSP headers which blocks parts of uaa-customized 

## security considerations
It's not good to pin back but as the `76` release stands, it breaks our uaa-customized release functionality
