### PR TITLE
feat: Add pages.support UAA group for adding support users

### DIFF
--- a/bosh/opsfiles/uaa-groups.yml
+++ b/bosh/opsfiles/uaa-groups.yml
@@ -2,4 +2,5 @@
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/scim/groups?
   value:
     pages.admin: "Administrators for the Pages product"
+    pages.support: "Support users for the Pages product"
     pages.user: "Users for the Pages product"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `pages.support` UAA group

## Supporting info
See PR for Pages implementation https://github.com/cloud-gov/pages-core/pull/3949

## security considerations
Adds the ability to have more fine grained authorization for Pages support users and follows the least privilege model.
