### PR TITLE
Increase gorouter CPU headroom with bigger and more instances

### DIFF
--- a/bosh/opsfiles/scaling-production.yml
+++ b/bosh/opsfiles/scaling-production.yml
@@ -41,10 +41,10 @@
 # gorouters
 - type: replace
   path: /instance_groups/name=router/instances
-  value: 7
+  value: 10
 - type: replace
   path: /instance_groups/name=router/vm_type
-  value: c5.xlarge
+  value: c5.2xlarge
 
 # scheduler
 - type: replace


### PR DESCRIPTION
Resolves https://github.com/cloud-gov/private/issues/592

## Changes proposed in this pull request:
- Bump to next instance size, `c5.2xlarge`
- Increase replicas

## security considerations
No considerations; just a change in quantity of an existing resource.