### PR TITLE
set maximum allowed disk for cc_deployment_updater to 6144 MB

### DIFF
--- a/bosh/opsfiles/api-defaults.yml
+++ b/bosh/opsfiles/api-defaults.yml
@@ -17,3 +17,7 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/client_max_body_size?
   value: "1536M"
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/maximum_app_disk_in_mb?
+  value: 6144


### PR DESCRIPTION
## Changes proposed in this pull request:

This was a tricky one. We had a customer who was seeing extraneous app instances when they did a rolling restart via `cf restart <app> -rolling`. They'd be left with two deployments of their app, one with 2/2 instances as per their manifest, and another deployment with 1/1 instances. The CLI output looks something like:

```
name   requested state   processes          routes
cms    started           web:2/2, web:1/1   cms-optimistic-lion-gs.app.cloud.gov
```

So they would have three total instances permanently, instead of the desired 2 instances. This had unfortunate side effects of using up more memory than intended.

It turns out that partially [this is how rolling deployments work](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html). In order to avoid application downtime, Cloud Foundry creates a new deployment and app instance (hence the 1/1 instances), waits for that application to be healthy, restarts the initial instances (the 2/2 instances) one at a time, then deletes the extra "standby" instance it created. By doing this, Cloud Foundry ensures that there is always an application available to serve the incoming requests.

There is a job in the CF deployment called the `cc_deployment_updater`, which is supposed to remove the extra "standby" instance once the restart is complete. But when I logged at the logs for that job, I noticed it was failing with this error:

```
{
    "timestamp": "2022-10-26T19:25:59.494054371Z",
    "message": "error-scaling-deployment",
    "log_level": "error",
    "source": "cc.deployment_updater.update",
    "data": {
        "deployment_guid": "<redacted>",
        "error": "Sequel::ValidationFailed",
        "error_message": "disk_quota too much disk requested (requested 4096 MB - must be less than 2048 MB)",
    }
}
```

This error made some sense because indeed this customer is specifying 4096 MB of disk space per instance. And after pairing with Van, we noticed that while our platform in general supports 6144 MB as the maximum disk quota per instance, the configuration for the `cc_deployment_updater` job was configured to only support 2048 MB.  Once we manually updated the job config to 6144 MB of maximum disk quota, the job correctly cleaned up old instances.

So this PR updates our BOSH ops file to permanently update the `cc_deployment_updater` job config to specify 6144 MB as the maximum disk quota, in line with the rest of the platform config.

## security considerations

There are no security considerations to increasing the support disk quota size that I am aware of. And overall we're fixing a bug in our system encountered by at least 2 customers and ensuring consistency in our platform settings.
