### PR TITLE
add feature flag to enable route sharing

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -93,6 +93,7 @@ jobs:
         space_developer_env_var_visibility
         service_instance_sharing
         resource_matching
+        route_sharing
       DISABLED_FEATURE_FLAGS: |
         user_org_creation
         hide_marketplace_from_unauthenticated_users
@@ -579,6 +580,7 @@ jobs:
         space_developer_env_var_visibility
         service_instance_sharing
         resource_matching
+        route_sharing
       DISABLED_FEATURE_FLAGS: |
         user_org_creation
         hide_marketplace_from_unauthenticated_users
@@ -1124,6 +1126,7 @@ jobs:
         space_developer_env_var_visibility
         service_instance_sharing
         resource_matching
+        route_sharing
       DISABLED_FEATURE_FLAGS: |
         user_org_creation
         hide_marketplace_from_unauthenticated_users


### PR DESCRIPTION
## Changes proposed in this pull request:

[Based on a customer request](https://cloud-gov-new.zendesk.com/agent/tickets/6185), we've enabled the feature of sharing routes between spaces at the platform level

## security considerations

I don't think there is any major security implication here. Users need space developer permissions in both spaces to share routes between spaces, so using this feature is still tightly restricted by role. See the CF documentation: https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#share-route
