### PR TITLE
chore: Bump app disk storage to 7GB

### DIFF
--- a/bosh/opsfiles/api-defaults.yml
+++ b/bosh/opsfiles/api-defaults.yml
@@ -8,11 +8,11 @@
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_app_disk_in_mb?
-  value: 6144
+  value: 7168
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?
-  value: 6144
+  value: 7168
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/client_max_body_size?
@@ -20,4 +20,4 @@
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/maximum_app_disk_in_mb?
-  value: 6144
+  value: 7168

--- a/bosh/opsfiles/diego-cell-disk.yml
+++ b/bosh/opsfiles/diego-cell-disk.yml
@@ -1,3 +1,3 @@
 - type: replace
   path: /instance_groups/name=diego-cell/vm_extensions/0
-  value: 250GB_ephemeral_disk
+  value: 300GB_ephemeral_disk


### PR DESCRIPTION
Updates to support https://github.com/cloud-gov/product/issues/2339

## Changes proposed in this pull request:
- Bumps max app disk storage to 7GB

## security considerations
None

## Background
- PR https://github.com/cloud-gov/cg-deploy-cf/pull/497
- PR https://github.com/cloud-gov/cg-deploy-cf/pull/710