### PR TITLE
Allow generating missing certificate

### DIFF
--- a/bosh/opsfiles/remove-routing-components-for-transition.yml
+++ b/bosh/opsfiles/remove-routing-components-for-transition.yml
@@ -30,12 +30,3 @@
 
 - type: remove
   path: /variables/name=diego_locket_client
-
-- type: remove
-  path: /variables/name=routing_api_ca
-
-- type: remove
-  path: /variables/name=routing_api_tls
-
-- type: remove
-  path: /variables/name=routing_api_tls_client


### PR DESCRIPTION
In cf v24.6.0, the router job now expects this certificate to exist in the secret store. We stopped generating it when we added these lines to the opsfile in cfb7e89. The secrets remained in the secret store in dev and staging, but were removed in production. Now that they're required by the job, dev and staging are using the previously-generated certs that remain in the secret store, but prod is failing because the secret was deleted. This change should allow the cert to be regenerated.

## security considerations

This will generate a certificate that will be used by the routing API, which is internal to our system.