### PR TITLE
Rollback loggregator for stratos

### DIFF
--- a/bosh/opsfiles/loggregator.yml
+++ b/bosh/opsfiles/loggregator.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /releases/-
+  value:
+    name: loggregator
+    sha1: af9a37be9fe1cc814165ac4c01086a8f290cc3e5
+    url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.7.4
+    version: 106.7.4

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -68,6 +68,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
       - cf-manifests/bosh/opsfiles/content-security-policy.yml
+      - cf-manifests/bosh/opsfiles/loggregator.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -555,6 +556,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+      - cf-manifests/bosh/opsfiles/loggregator.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -1057,6 +1059,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+      - cf-manifests/bosh/opsfiles/loggregator.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Rolls back the loggregator version so that the log stream in Stratos can work

## security considerations
This should only be a temporary change until a better solution can be implemented.
