### PR TITLE
Enabling cflinuxsf4 for dev

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -39,7 +39,7 @@ jobs:
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
       - cf-deployment/operations/use-bionic-stemcell.yml
-      - cf-deployment/operations/add-cflinuxfs4.yml
+      - cf-deployment/operations/experimental/add-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/users.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -39,6 +39,7 @@ jobs:
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
       - cf-deployment/operations/use-bionic-stemcell.yml
+      - cf-deployment/operations/add-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/users.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- This makes so you can use cflinuxsf4 with supported buildpacks in DEV
- cflinuxsf3 is still default


## security considerations
None