### PR TITLE
Testing out max-in-flight settings in Dev

### DIFF
--- a/bosh/opsfiles/scaling-development.yml
+++ b/bosh/opsfiles/scaling-development.yml
@@ -45,6 +45,11 @@
 - type: replace
   path: /instance_groups/name=router/vm_type
   value: t3.small
+- type: replace
+  path: /instance_groups/name=router/update?
+  value:
+    max_in_flight: 20%
+    canaries: 20%  
 
 # scheduler
 - type: replace
@@ -61,6 +66,12 @@
 - type: replace
   path: /instance_groups/name=doppler/vm_type
   value: t3.large
+- type: replace
+  path: /instance_groups/name=doppler/update?
+  value:
+    max_in_flight: 20%
+    canaries: 20%
+
 
 # log-cache
 - type: replace
@@ -69,6 +80,11 @@
 - type: replace
   path: /instance_groups/name=log-cache/vm_type
   value: t3.large
+- type: replace
+  path: /instance_groups/name=log-cache/update?
+  value:
+    max_in_flight: 40%
+    canaries: 40%   
 
 # log-api
 - type: replace
@@ -77,6 +93,11 @@
 - type: replace
   path: /instance_groups/name=log-api/vm_type
   value: t3.medium
+- type: replace
+  path: /instance_groups/name=log-api/update?
+  value:
+    max_in_flight: 30%
+    canaries: 30%
 
 # diego (platform and customer)
 - type: replace
@@ -85,6 +106,12 @@
 - type: replace
   path: /instance_groups/name=diego-platform-cell/vm_type
   value: t3.xlarge
+- type: replace
+  path: /instance_groups/name=diego-cell/update?
+  value:
+    max_in_flight: 11%
+    canaries: 11%
+
 
 # rotate-cc-database-key
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:

- Making changes to the update: blocks for the following instance groups:
  - diego-cell
  - doppler
  - log-api
  - log-cache
  - router
- Testing this in dev first, there should be no change in deployment behavior since it is so small, but doing this to validate the syntax before making similar changes to staging/prod
- The changes were made to an existing ops file since it is likely in the future these values would be reviewed as the number of instances was changed and helping the operators out by locating these changes near each other.
-
## security considerations

There is no impact on security, this only changes the number of instances bosh will updated in parallel
