### PR TITLE
Update scaling-production.yml

### DIFF
--- a/bosh/opsfiles/scaling-production.yml
+++ b/bosh/opsfiles/scaling-production.yml
@@ -45,6 +45,11 @@
 - type: replace
   path: /instance_groups/name=router/vm_type
   value: c5.2xlarge
+- type: replace
+  path: /instance_groups/name=router/update?
+  value:
+    max_in_flight: 20%
+    canaries: 20%
 
 # scheduler
 - type: replace
@@ -62,6 +67,11 @@
   path: /instance_groups/name=diego-cell/vm_type
   value: m5.2xlarge
 - type: replace
+  path: /instance_groups/name=diego-cell/update?
+  value:
+    max_in_flight: 11%
+    canaries: 11%
+- type: replace
   path: /instance_groups/name=diego-platform-cell/vm_type
   value: m5.2xlarge
 
@@ -72,6 +82,11 @@
 - type: replace
   path: /instance_groups/name=doppler/vm_type
   value: m5.2xlarge
+- type: replace
+  path: /instance_groups/name=doppler/update?
+  value:
+    max_in_flight: 20%
+    canaries: 20%
 
 # log-cache
 - type: replace
@@ -80,6 +95,11 @@
 - type: replace
   path: /instance_groups/name=log-cache/vm_type
   value: m5.2xlarge
+- type: replace
+  path: /instance_groups/name=log-cache/update?
+  value:
+    max_in_flight: 40%
+    canaries: 40%   
 
 # log-api
 - type: replace
@@ -88,6 +108,11 @@
 - type: replace
   path: /instance_groups/name=log-api/vm_type
   value: m5.xlarge
+- type: replace
+  path: /instance_groups/name=log-api/update?
+  value:
+    max_in_flight: 30%
+    canaries: 30%
 
 # rotate-cc-database-key
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:

- Making changes to the `update:` blocks for the following instance groups:
  - diego-cell
  - doppler
  - log-api
  - log-cache
  - router
- Tested this in dev first, there should be only a change to the number of vms allowed to update in parallel on a bosh deploy, no other changes to the configuration of vms is included.
- The changes were made to an existing ops file since it is likely in the future these values would be reviewed as the number of instances was changed and helping the operators out by locating these changes near each other.

## security considerations
There is no impact on security, this only changes the number of instances bosh will updated in parallel