### PR TITLE
Enable UAA pages-client-dev in dev and staging

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -42,6 +42,7 @@ jobs:
       - cf-deployment/operations/experimental/add-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
+      - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
       - cf-manifests/bosh/opsfiles/users.yml
       - cf-manifests/bosh/opsfiles/secureproxy.yml
       - cf-manifests/bosh/opsfiles/apps-domain.yml
@@ -537,6 +538,7 @@ jobs:
       - cf-deployment/operations/experimental/add-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
+      - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
       - cf-manifests/bosh/opsfiles/pages-clients-staging.yml
       - cf-manifests/bosh/opsfiles/users.yml
       - cf-manifests/bosh/opsfiles/secureproxy.yml


### PR DESCRIPTION
Related to [#4106](https://github.com/cloud-gov/pages-core/issues/4106) and [#3947 ](https://github.com/cloud-gov/pages-core/issues/3947)

## Changes proposed in this pull request:
- Enables the pages-client-dev in dev and staging environment
- Allows pages to authenticate users in a dev deploy env

## security considerations
Add new dev auth client for pages development. Adds to dev and staging UAA for more flexibility in pages dev env
