### PR TITLE
updating secureproxy ops file to remove legacy override value

### DIFF
--- a/bosh/opsfiles/secureproxy.yml
+++ b/bosh/opsfiles/secureproxy.yml
@@ -76,9 +76,12 @@
 # https://github.com/cloudfoundry-incubator/routing-release#configure-load-balancer-healthchecks-for-gorouter
 # Any other setting and the health check will respond 200 for this period of time, but the router will not actually be up
 # TODO: Revisit this setting once https://github.com/cloudfoundry/gorouter/issues/160 is closed
-- type: replace
-  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/load_balancer_healthy_threshold?
-  value: 0
+# 05/03/2023 - commenting this out as this block was from an issue since closed in 2017 - in theory since we use BOSH VM-Extensions, BOSH waits for pre-start, start, and post-start
+# scripts on the VM to be green before registering the target to the target group via vm-extension. BOSH CPI then waits for the healthcheck for this target to be green in
+# target group before moving onto the next router.
+#- type: replace
+#  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/load_balancer_healthy_threshold?
+#  value: 0
 
 - type: replace
   path: /instance_groups/name=router/jobs/name=secureproxy/properties/secureproxy/tls_cert?


### PR DESCRIPTION
## Changes proposed in this pull request:
- Commenting out legacy ops file setting `router.load_balancer_healthy_threshold` to `0`
- The reason for this back in 2017 was the ELB health-checks added the router to the target poll under the default 20 seconds set in the spec - that behavior has since changed and we can go back to default spec

## security considerations
Removing old and no longer relevant code from deploys helps support triage of changes/issues faster and in line with default release values and behaviors. 
