### PR TITLE
Revert load_balancer_healthy_threshold to old state of 0

### DIFF
--- a/bosh/opsfiles/secureproxy.yml
+++ b/bosh/opsfiles/secureproxy.yml
@@ -76,12 +76,10 @@
 # https://github.com/cloudfoundry-incubator/routing-release#configure-load-balancer-healthchecks-for-gorouter
 # Any other setting and the health check will respond 200 for this period of time, but the router will not actually be up
 # TODO: Revisit this setting once https://github.com/cloudfoundry/gorouter/issues/160 is closed
-# 05/03/2023 - commenting this out as this block was from an issue since closed in 2017 - in theory since we use BOSH VM-Extensions, BOSH waits for pre-start, start, and post-start
-# scripts on the VM to be green before registering the target to the target group via vm-extension. BOSH CPI then waits for the healthcheck for this target to be green in
-# target group before moving onto the next router.
-#- type: replace
-#  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/load_balancer_healthy_threshold?
-#  value: 0
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/load_balancer_healthy_threshold?
+  value: 0
 
 - type: replace
   path: /instance_groups/name=router/jobs/name=secureproxy/properties/secureproxy/tls_cert?


### PR DESCRIPTION
## Changes proposed in this pull request:
- Revert the last change for load_balancer_healthy_threshold back to 0

## security considerations
Going back to original settings for timeout values to lower 502 counts
