### PR TITLE
Add RDS CAs to cflinuxfs4 rootfs

### DIFF
--- a/bosh/opsfiles/diego-rds-certs.yml
+++ b/bosh/opsfiles/diego-rds-certs.yml
@@ -261,3 +261,12 @@
 - type: replace
   path: /instance_groups/name=diego-platform-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs?/trusted_certs/-
   value: *rds-ca
+
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs4-rootfs-setup/properties/cflinuxfs4-rootfs?/trusted_certs/-
+  value: *rds-ca
+
+- type: replace
+  path: /instance_groups/name=diego-platform-cell/jobs/name=cflinuxfs4-rootfs-setup/properties/cflinuxfs4-rootfs?/trusted_certs/-
+  value: *rds-ca


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds the RDS CA to the rootfs for cflinuxfs4 on cells
-
-

## security considerations
Allows apps to use TLS to connect to RDS databases on the cflinuxfs4 stack
