### PR TITLE
Reorder applying cflinuxfs4 ops files to pick up trusted certs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -64,13 +64,13 @@ jobs:
       - cf-manifests/bosh/opsfiles/scaling-development.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
       - cf-manifests/bosh/opsfiles/content-security-policy.yml
       - cf-manifests/bosh/opsfiles/loggregator.yml
-      - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
@@ -560,12 +560,12 @@ jobs:
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
       - cf-manifests/bosh/opsfiles/loggregator.yml
-      - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
@@ -1067,10 +1067,10 @@ jobs:
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
       - cf-manifests/bosh/opsfiles/loggregator.yml
-      - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
-  Reorder applying cflinuxfs4 ops files to pick up trusted certs


## security considerations
Just reorders the applying of ops files, no change to security
