### PR TITLE
Adding az3 and az4 for elasticsearch to ASGs

### DIFF
--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -199,6 +199,18 @@ resource "cloudfoundry_asg" "trusted_local_networks" {
     destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
     ports       = "443"
   }
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS Elasticsearch"
+    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
+    ports       = "443"
+  }
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS Elasticsearch"
+    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
+    ports       = "443"
+  }
   # S3 Gateway access
   rule {
     protocol    = "tcp"
@@ -272,6 +284,18 @@ resource "cloudfoundry_asg" "trusted_local_networks_egress" {
     protocol    = "tcp"
     description = "Allow access to AWS Elasticsearch"
     destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
+    ports       = "443"
+  }
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS Elasticsearch"
+    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
+    ports       = "443"
+  }
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS Elasticsearch"
+    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
     ports       = "443"
   }
   # S3 Gateway access


### PR DESCRIPTION
## Changes proposed in this pull request:
- This supports the expansion for az3 and az4 for elasticsearch to be added to the ASGs created by Terraform
-

Do not merge until cg-provision corresponding change is deployed

## security considerations
The changes are not picked up until apps are restarted
