### PR TITLE
Changes needed to support cf-deployment v30.1.0

### DIFF
--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -162,6 +162,8 @@
         vpa: {from: vpa-platform}
       provides:
         cni_config: {as: cni_config_platform}
+    - name: silk-datastore-syncer
+      release: silk
     - name: loggr-udp-forwarder
       release: loggregator-agent
       properties:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -38,7 +38,7 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
-      - cf-deployment/operations/experimental/add-cflinuxfs4.yml
+      - cf-deployment/operations/use-cflinuxfs3.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
@@ -533,7 +533,7 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
-      - cf-deployment/operations/experimental/add-cflinuxfs4.yml
+      - cf-deployment/operations/use-cflinuxfs3.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
@@ -1039,7 +1039,7 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
-      - cf-deployment/operations/experimental/add-cflinuxfs4.yml
+      - cf-deployment/operations/use-cflinuxfs3.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/pages-clients-production.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove experimental cflinuxfs4 file since it's now default in main mainifest
- Add ops file for keeping cflinuxfs3 and buildpacks for now - cflinuxfs4 is still default
- Add new `silk-datastore-syncer` job to `diego-platform-cell` to match main

## security considerations
By keeping up to date on the latest releases we insure a patched and stable platform.
