### PR TITLE
Create ASG for accessing platform services

### DIFF
--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -311,6 +311,24 @@ resource "cloudfoundry_asg" "smtp" {
   }
 }
 
+resource "cloudfoundry_asg" "platform_services_egress" {
+  name = "platform_services_egress"
+
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to platform services"
+    destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az1
+    ports       = "443"
+  }
+
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to platform services"
+    destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az2
+    ports       = "443"
+  }
+}
+
 # Default global running ASG
 resource "cloudfoundry_default_asg" "running" {
     name = "running"

--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -440,6 +440,7 @@ resource "cloudfoundry_space" "opensearch-dashboards-proxy" {
   name = "opensearch-dashboards-proxy"
   org  = cloudfoundry_org.cloud-gov.id
   asgs = [
+    cloudfoundry_asg.public_networks.id,
     cloudfoundry_asg.dns.id,
     cloudfoundry_asg.internal_services_egress.id,
   ]

--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -440,14 +440,11 @@ resource "cloudfoundry_space" "opensearch-dashboards-proxy" {
   name = "opensearch-dashboards-proxy"
   org  = cloudfoundry_org.cloud-gov.id
   asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
     cloudfoundry_asg.public_networks.id,
     cloudfoundry_asg.dns.id,
     cloudfoundry_asg.internal_services_egress.id,
   ]
   staging_asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
     cloudfoundry_asg.dns.id,
   ]
 }

--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -436,6 +436,22 @@ resource "cloudfoundry_space" "cspr-collector" {
   ]
 }
 
+resource "cloudfoundry_space" "opensearch-dashboards-proxy" {
+  name = "opensearch-dashboards-proxy"
+  org  = cloudfoundry_org.cloud-gov.id
+  asgs = [
+    cloudfoundry_asg.trusted_local_networks.id,
+    cloudfoundry_asg.public_networks.id,
+    cloudfoundry_asg.dns.id,
+    cloudfoundry_asg.internal_services_egress.id,
+  ]
+  staging_asgs = [
+    cloudfoundry_asg.trusted_local_networks.id,
+    cloudfoundry_asg.public_networks.id,
+    cloudfoundry_asg.dns.id,
+  ]
+}
+
 # Federalist/Pages
 
 data "cloudfoundry_org" "gsa-18f-federalist" {

--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -311,19 +311,19 @@ resource "cloudfoundry_asg" "smtp" {
   }
 }
 
-resource "cloudfoundry_asg" "platform_services_egress" {
-  name = "platform_services_egress"
+resource "cloudfoundry_asg" "internal_services_egress" {
+  name = "internal_services_egress"
 
   rule {
     protocol    = "tcp"
-    description = "Allow access to platform services"
+    description = "Allow access to internal services on port 443 - AZ 1"
     destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az1
     ports       = "443"
   }
 
   rule {
     protocol    = "tcp"
-    description = "Allow access to platform services"
+    description = "Allow access to internal services on port 443 - AZ 2"
     destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az2
     ports       = "443"
   }

--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -440,7 +440,6 @@ resource "cloudfoundry_space" "opensearch-dashboards-proxy" {
   name = "opensearch-dashboards-proxy"
   org  = cloudfoundry_org.cloud-gov.id
   asgs = [
-    cloudfoundry_asg.public_networks.id,
     cloudfoundry_asg.dns.id,
     cloudfoundry_asg.internal_services_egress.id,
   ]


### PR DESCRIPTION
## Changes proposed in this pull request:

We have deployed a new service in our services subnets that we want our application to be able to reach out, so we need a new ASG that allows traffic to those IP ranges/ports. 

- Adds new `internal_services_egress` ASG for allowing traffic to internal services
- Add new `opensearch-dashboards-proxy` space using the new ASG

## security considerations

My biggest concern was whether creating this ASG would allow cloud.gov **customers** (not operators) to bind this security group to their applications and be able to make requests to our internal services. However, this is not the case because there are access controls built into security groups:

> Org Manager | Can see globally–enabled security groups or groups associated with a space they can see
> Space Auditor | Can see globally–enabled security groups or groups associated with a space they can see
> Space Developer | Can see globally–enabled security groups or groups associated with a space they can see

From: https://v3-apidocs.cloudfoundry.org/version/3.130.0/index.html#list-security-groups

Thus, platform users can only see globally-enabled security groups, which is this subset: https://github.com/cloud-gov/cg-deploy-cf/blob/main/terraform/stack/asg.tf#L338-L352. I have confirmed this behavior with manual testing as a non-admin users in the CF dev environment.

So platform users will not have access to use this ASG.
