### PR TITLE
change ASGs for proxy

### DIFF
--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -464,7 +464,7 @@ resource "cloudfoundry_space" "opensearch-dashboards-proxy" {
   name = "opensearch-dashboards-proxy"
   org  = cloudfoundry_org.cloud-gov.id
   asgs = [
-    cloudfoundry_asg.public_networks.id,
+    cloudfoundry_asg.public_networks_egress.id,
     cloudfoundry_asg.dns.id,
     cloudfoundry_asg.internal_services_egress.id,
   ]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Change ASG from `public_networks` to `public_networks_egress`

## security considerations

This proxy needs public internet egress to make requests to UAA. We thought that the `public_networks` ASG would give the necessary access, but it seems `public_networks_egress` ASG is required.
