### PR TITLE
Keep fs3 as option

### DIFF
--- a/bosh/opsfiles/enable-cflinuxfs4.yml
+++ b/bosh/opsfiles/enable-cflinuxfs4.yml
@@ -19,25 +19,53 @@
   path: /instance_groups/name=diego-platform-cell/jobs/name=rep/properties/diego/rep/preloaded_rootfses/-
   value: cflinuxfs4:/var/vcap/packages/cflinuxfs4/rootfs.tar
 
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=java-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=staticfile-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=ruby-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=dotnet-core-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=nodejs-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=go-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=python-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=php-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=nginx-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=r-buildpack-cflinuxfs3?
-- type: remove
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=binary-buildpack-cflinuxfs3?
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/droplet_destinations/cflinuxfs3?
+  value: /home/vcap
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/lifecycle_bundles/buildpack~1cflinuxfs3?
+  value: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/name=cflinuxfs4:before
+  value:
+    description: Cloud Foundry Linux-based filesystem (Ubuntu 18.04)
+    name: cflinuxfs3
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/diego/droplet_destinations/cflinuxfs3?
+  value: /home/vcap
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/diego/lifecycle_bundles/buildpack~1cflinuxfs3?
+  value: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/diego/droplet_destinations/cflinuxfs3?
+  value: /home/vcap
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/diego/lifecycle_bundles/buildpack~1cflinuxfs3?
+  value: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/diego/droplet_destinations/cflinuxfs3?
+  value: /home/vcap
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/diego/lifecycle_bundles/buildpack~1cflinuxfs3?
+  value: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup?
+  value:
+    name: cflinuxfs3-rootfs-setup
+    properties:
+      cflinuxfs3-rootfs:
+        trusted_certs:
+        - ((diego_instance_identity_ca.ca))
+        - ((credhub_tls.ca))
+        - ((uaa_ssl.ca))
+    release: cflinuxfs3
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/rep/preloaded_rootfses/0:before
+  value: cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar
+- type: replace
+  path: /releases/name=cflinuxfs4:before
+  value:
+    name: cflinuxfs3
+    sha1: 5463400cd5490e9d847326668d504a8833cf3e4e
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.369.0
+    version: 0.369.0

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -38,7 +38,6 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
-      - cf-deployment/operations/use-cflinuxfs3.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
@@ -533,7 +532,6 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
-      - cf-deployment/operations/use-cflinuxfs3.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
@@ -1039,7 +1037,6 @@ jobs:
       - cf-deployment/operations/stop-skipping-tls-validation.yml
       - cf-deployment/operations/set-bbs-active-key.yml
       - cf-deployment/operations/enable-service-discovery.yml
-      - cf-deployment/operations/use-cflinuxfs3.yml
       - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
       - cf-manifests/bosh/opsfiles/clients.yml
       - cf-manifests/bosh/opsfiles/pages-clients-production.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- CF-deployment 31 removes the ops file for fs3. This is putting it back so we can keep it around until we actually remove it in september.
- Since the old ops files added the buildpack part, we are skipping that part now 
-

## security considerations
None, keeping stuff the same
