### PR TITLE
Rename staging CF security groups

### DIFF
--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -364,8 +364,8 @@ resource "cloudfoundry_default_asg" "staging" {
     name = "staging"
     asgs = [
       cloudfoundry_asg.dns.id,
-      cloudfoundry_asg.public_networks.id,
-      cloudfoundry_asg.trusted_local_networks.id,
+      cloudfoundry_asg.public_networks_egress.id,
+      cloudfoundry_asg.trusted_local_networks_egress.id,
     ]
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- rename public_networks / trusted_local_networks -> public_networks_egress / trusted_local_networks_egress


## security considerations
N/A
