### PR TITLE
Moving content-security policy 

### DIFF
--- a/bosh/opsfiles/content-security-policy.yml
+++ b/bosh/opsfiles/content-security-policy.yml
@@ -5,3 +5,12 @@
     report_only: ((csp-report-only))
     report_uri: ((csp-report-uri))
     host_patterns: ((csp-host-patterns))
+
+# This ops file is only currently used in dev so putting the router-main instance group override here
+- type: replace
+  path: /instance_groups/name=router-main/jobs/name=secureproxy/properties/secureproxy/csp?
+  value:
+    enable: ((csp-enabled))
+    report_only: ((csp-report-only))
+    report_uri: ((csp-report-uri))
+    host_patterns: ((csp-host-patterns))

--- a/bosh/opsfiles/router-main.yml
+++ b/bosh/opsfiles/router-main.yml
@@ -83,15 +83,6 @@
   path: /instance_groups/name=router-main/jobs/name=gorouter/properties/request_timeout_in_seconds?
   value: 3600
 
-# From cf-manifests/bosh/opsfiles/content-security-policy.yml
-- type: replace
-  path: /instance_groups/name=router-main/jobs/name=secureproxy/properties/secureproxy/csp?
-  value:
-    enable: ((csp-enabled))
-    report_only: ((csp-report-only))
-    report_uri: ((csp-report-uri))
-    host_patterns: ((csp-host-patterns))
-
 
 # Needed for BOSH DNS, concatenate the new router group to the existing one (not overwrite)
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Moving content-security policy into ops file instead of router-main overrides file as it only exists in development, don't want this change being picked up for stage/prod
-
-

## security considerations
None, moves contents of an ops file to another file
