### PR TITLE
Reorder router-main 

### DIFF
--- a/ci/create-router-main.sh
+++ b/ci/create-router-main.sh
@@ -8,7 +8,7 @@ bosh int cf-deployment/cf-deployment.yml --path /instance_groups/name=router > r
 ## Create ops file header
 cat > router_main.yml <<EOF
 - type: replace
-  path: /instance_groups/name=router-main?
+  path: /instance_groups/name=router:after
   value:
 EOF
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Reorder router-main to be after router rather than appended to the end of the manifest.  This keeps the desired order of updates of the CF components
-
-

## security considerations
Just and order change, no security issues
