### PR TITLE
Adding autoscaler client

### DIFF
--- a/bosh/opsfiles/add-autoscaler-client.yml
+++ b/bosh/opsfiles/add-autoscaler-client.yml
@@ -1,0 +1,12 @@
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/autoscaler_client_id?
+  value:
+    authorized-grant-types: client_credentials
+    authorities: cloud_controller.read,cloud_controller.admin,uaa.resource
+    secret: "((autoscaler_client_secret))"
+
+- type: replace
+  path: /variables/-
+  value:
+    name: autoscaler_client_secret
+    type: password

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -76,6 +76,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-main-dev.yml
+      - cf-manifests/bosh/opsfiles/add-autoscaler-client.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -574,6 +575,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/loggregator.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
+      - cf-manifests/bosh/opsfiles/add-autoscaler-client.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -1082,6 +1084,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/loggregator.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
+      - cf-manifests/bosh/opsfiles/add-autoscaler-client.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- This adds the autoscaler client to UAA used by CF in dev/stage/prod
- Password is dynamically created and managed by the environment level credhub.
-

## security considerations
Password is dynamically created and managed by the environment level credhub.  The credhub value (with full path) will be used in ops files for autoscaler
