### PR TITLE
Add test CDN app & service

### DIFF
--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -21,6 +21,9 @@ resource "cloudfoundry_route" "test_cdn_route" {
   hostname = "test-cdn"
 }
 
+# DNS records:
+# https://github.com/cloud-gov/cg-provision/blob/417000c786a101988c3edd965f7c78f66ad334fe/terraform/stacks/dns/staging.tf#L25-L30
+# https://github.com/cloud-gov/cg-provision/blob/417000c786a101988c3edd965f7c78f66ad334fe/terraform/stacks/dns/production.tf#L12-L17
 resource "cloudfoundry_service_instance" "test_cdn_instance" {
   name         = "test-cdn-service"
   space        = var.space_id

--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -1,0 +1,45 @@
+locals {
+  domain_name = var.iaas_stack_name == "staging" ? "fr-stage.cloud.gov" : "fr.cloud.gov"
+}
+
+data "cloudfoundry_domain" "fr_domain" {
+  name = local.domain_name
+}
+
+data "cloudfoundry_service" "external_domain" {
+  name = "external-domain"
+}
+
+resource "zipper_file" "test_cdn_src" {
+  source      = "https://github.com/cloud-gov/cf-hello-worlds/tree/main/static"
+  output_path = "test-static-app.zip"
+}
+
+resource "cloudfoundry_route" "test_cdn_route" {
+  domain   = data.cloudfoundry_domain.fr_domain.id
+  space    = var.space_id
+  hostname = "test-cdn"
+}
+
+resource "cloudfoundry_service_instance" "test_cdn_instance" {
+  name         = "test-cdn-service"
+  space        = var.space_id
+  service_plan = data.cloudfoundry_service.external_domain.service_plans["domain-with-cdn"]
+  json_params  = "{\"domains\": \"test-cdn.${local.domain_name}\"}"
+}
+
+resource "cloudfoundry_app" "test-cdn" {
+  name             = "test-cdn"
+  buildpack        = "staticfile_buildpack"
+  space            = var.space_id
+  path             = zipper_file.test_cdn_src.output_path
+  source_code_hash = zipper_file.test_cdn_src.output_sha
+
+  routes {
+    route = cloudfoundry_route.test_cdn_route.id
+  }
+
+  service_binding {
+    service_instance = cloudfoundry_service_instance.test_cdn_instance.id
+  }
+}

--- a/terraform/modules/test_cdn/variables.tf
+++ b/terraform/modules/test_cdn/variables.tf
@@ -1,0 +1,7 @@
+variable "iaas_stack_name" {
+}
+
+variable "space_id" {
+  type = string
+  description = "Space GUID to deploy test CDN app"
+}

--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -1,36 +1,5 @@
-variable "remote_state_bucket" {
-}
-
-variable "tooling_stack_name" {
-}
-
-variable "iaas_stack_name" {
-}
-
-variable "domain_name" {
-}
-
 terraform {
   backend "s3" {
-  }
-}
-
-provider "cloudfoundry" {
-}
-
-data "terraform_remote_state" "iaas" {
-  backend = "s3"
-  config = {
-    bucket = var.remote_state_bucket
-    key    = "${var.iaas_stack_name}/terraform.tfstate"
-  }
-}
-
-data "terraform_remote_state" "tooling" {
-  backend = "s3"
-  config = {
-    bucket = var.remote_state_bucket
-    key    = "${var.tooling_stack_name}/terraform.tfstate"
   }
 }
 

--- a/terraform/stack/data.tf
+++ b/terraform/stack/data.tf
@@ -1,0 +1,20 @@
+data "terraform_remote_state" "iaas" {
+  backend = "s3"
+  config = {
+    bucket = var.remote_state_bucket
+    key    = "${var.iaas_stack_name}/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "tooling" {
+  backend = "s3"
+  config = {
+    bucket = var.remote_state_bucket
+    key    = "${var.tooling_stack_name}/terraform.tfstate"
+  }
+}
+
+data "cloudfoundry_space" "hello_worlds" {
+  name = "hello-worlds"
+  org  = cloudfoundry_org.cloud-gov.id
+}

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -1,0 +1,6 @@
+module "test_cdn" {
+  count           = var.iaas_stack_name == "development" ? 0 : 1
+  source          = "../modules/test_cdn"
+  iaas_stack_name = var.iaas_stack_name
+  space_id        = data.cloudfoundry_space.hello_worlds.id
+}

--- a/terraform/stack/providers.tf
+++ b/terraform/stack/providers.tf
@@ -1,0 +1,6 @@
+provider "cloudfoundry" {
+}
+
+provider "zipper" {
+  skip_ssl_validation = false
+}

--- a/terraform/stack/variables.tf
+++ b/terraform/stack/variables.tf
@@ -1,0 +1,11 @@
+variable "remote_state_bucket" {
+}
+
+variable "tooling_stack_name" {
+}
+
+variable "iaas_stack_name" {
+}
+
+variable "domain_name" {
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add test CDN app & service so that we can effectively perform uptime monitoring against a site loading from Cloudfront

## security considerations

None
