### PR TITLE
Fix app zipfile for test CDN app

### DIFF
--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -1,5 +1,7 @@
 locals {
   domain_name = var.iaas_stack_name == "staging" ? "fr-stage.cloud.gov" : "fr.cloud.gov"
+  clone_dir = "${path.module}/cf-hello-worlds"
+  zip_output_filepath = "${path.module}/hello-world-static.zip"
 }
 
 data "cloudfoundry_domain" "fr_domain" {
@@ -15,9 +17,22 @@ data "cloudfoundry_space" "hello_worlds" {
   org  = var.organization_id
 }
 
-resource "zipper_file" "test_cdn_src" {
-  source      = "https://github.com/cloud-gov/cf-hello-worlds/tree/main/static"
-  output_path = "test-static-app.zip"
+resource "null_resource" "git_clone" {
+  triggers = {
+    on_every_apply = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = "git clone https://github.com/cloud-gov/cf-hello-worlds.git ${local.clone_dir}"
+  }
+}
+
+data "archive_file" "test_cdn_app_src" {
+  depends_on  = [null_resource.git_clone]
+
+  output_path = local.zip_output_filepath
+  source_dir  = "${local.clone_dir}/static"
+  type        = "zip"
 }
 
 resource "cloudfoundry_route" "test_cdn_route" {
@@ -40,8 +55,8 @@ resource "cloudfoundry_app" "test-cdn" {
   name             = "test-cdn"
   buildpack        = "staticfile_buildpack"
   space            = data.cloudfoundry_space.hello_worlds.id
-  path             = zipper_file.test_cdn_src.output_path
-  source_code_hash = zipper_file.test_cdn_src.output_sha
+  path             = local.zip_output_filepath
+  source_code_hash = data.archive_file.test_cdn_app_src.output_sha256
 
   routes {
     route = cloudfoundry_route.test_cdn_route.id

--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -1,7 +1,7 @@
 locals {
   domain_name = var.iaas_stack_name == "staging" ? "fr-stage.cloud.gov" : "fr.cloud.gov"
-  clone_dir = "${path.module}/cf-hello-worlds"
-  zip_output_filepath = "${path.module}/hello-world-static.zip"
+  clone_dir = "${path.module}/${var.git_clone_dir}"
+  zip_output_filepath = "${path.module}/${var.zip_output_filename}"
 }
 
 data "cloudfoundry_domain" "fr_domain" {
@@ -23,7 +23,7 @@ resource "null_resource" "git_clone" {
   }
 
   provisioner "local-exec" {
-    command = "git clone https://github.com/cloud-gov/cf-hello-worlds.git ${local.clone_dir}"
+    command = "git clone ${var.source_code_repo} ${local.clone_dir}"
   }
 }
 
@@ -31,7 +31,7 @@ data "archive_file" "test_cdn_app_src" {
   depends_on  = [null_resource.git_clone]
 
   output_path = local.zip_output_filepath
-  source_dir  = "${local.clone_dir}/static"
+  source_dir  = "${local.clone_dir}/${var.source_code_path}"
   type        = "zip"
 }
 

--- a/terraform/modules/test_cdn/variables.tf
+++ b/terraform/modules/test_cdn/variables.tf
@@ -11,3 +11,27 @@ variable "space_name" {
   description = "Space name to use for test CDN app"
   default = "hello-worlds"
 }
+
+variable "source_code_repo" {
+  type = string
+  description = "HTTPS link to git repo containing source code for test CDN app"
+  default = "https://github.com/cloud-gov/cf-hello-worlds.git"
+}
+
+variable "source_code_path" {
+  type = string
+  description = "Path in source_code_repo containing app code"
+  default = "static"
+}
+
+variable "git_clone_dir" {
+  type = string
+  description = "Subdirectory of module path to clone git repo"
+  default = "cf-hello-worlds"
+}
+
+variable "zip_output_filename" {
+  type = string
+  description = "Name of zip file containing source code for test CDN app"
+  default = "hello-world-static.zip"
+}

--- a/terraform/modules/test_cdn/versions.tf
+++ b/terraform/modules/test_cdn/versions.tf
@@ -5,10 +5,5 @@ terraform {
       source  = "cloudfoundry-community/cloudfoundry"
       version = "< 1.0.0"
     }
-
-    zipper = {
-      source = "ArthurHlt/zipper"
-      version = "0.14.0"
-    }
   }
 }

--- a/terraform/stack/apps.tf
+++ b/terraform/stack/apps.tf
@@ -6,6 +6,5 @@ module "test_cdn" {
 
   providers = {
     cloudfoundry = cloudfoundry
-    zipper = zipper
   }
 }

--- a/terraform/stack/providers.tf
+++ b/terraform/stack/providers.tf
@@ -1,6 +1,2 @@
 provider "cloudfoundry" {
 }
-
-provider "zipper" {
-  skip_ssl_validation = false
-}

--- a/terraform/stack/versions.tf
+++ b/terraform/stack/versions.tf
@@ -5,10 +5,5 @@ terraform {
       source  = "cloudfoundry-community/cloudfoundry"
       version = "< 1.0.0"
     }
-
-    zipper = {
-      source = "ArthurHlt/zipper"
-      version = "0.14.0"
-    }
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

After #779, #780, and #781, the test CDN deployed correctly in staging, but visiting the URL gives a 403 error: https://test-cdn.fr-stage.cloud.gov/

The cause of the issue is that the source code for the app wasn't being zipped properly by the `zipper` provider. So Instead, I'm updating the code to the clone the source code manually and create the zip file using the `archive_file` resource built-in to Terraform.

## security considerations

None. These changes will fix deployment a "hello world" app which has no value except for allowing uptime monitoring of apps using a CDN.
