### PR TITLE
fix git clone not to clone if directory already exists

### DIFF
--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -23,7 +23,7 @@ resource "null_resource" "git_clone" {
   }
 
   provisioner "local-exec" {
-    command = "git clone ${var.source_code_repo} ${local.clone_dir}"
+    command = "if [ ! -d \"${local.clone_dir}\" ]; then git clone ${var.source_code_repo} ${local.clone_dir}; fi"
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Our CI scripts run `terraform apply` twice, which was causing `git clone` to run twice and causing errors. This fix ensures that `git clone` should not re-run unless necessary

## security considerations

None
