### PR TITLE
remove oauth provider ops file for dev

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -57,7 +57,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/uaa-groups.yml
       - cf-manifests/bosh/opsfiles/uaa-login.yml
       - cf-manifests/bosh/opsfiles/uaa-saml.yml
-      - cf-manifests/bosh/opsfiles/uaa-oauth-providers.yml
       - cf-manifests/bosh/opsfiles/uaa-user.yml
       - cf-manifests/bosh/opsfiles/uaa-cors.yml
       - cf-manifests/bosh/opsfiles/encryption.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove oauth provider ops file for dev since OAuth/OIDC integrations for customers will only be tested in staging or prod

## security considerations

None
