### PR TITLE
Update for CF v35.2 support, remap 8443 healthcheck to 9443

### DIFF
--- a/bosh/opsfiles/router-logstash.yml
+++ b/bosh/opsfiles/router-logstash.yml
@@ -111,3 +111,8 @@
   value:
     gorouter: nil
 
+# Avoid conflict with https://github.com/cloudfoundry/cf-deployment/pull/1141/files and use an alternate port
+- type: replace
+  path: /instance_groups/name=router-logstash/jobs/name=gorouter/properties/router/status?/tls?
+  value:
+    port: 9443

--- a/bosh/opsfiles/router-main.yml
+++ b/bosh/opsfiles/router-main.yml
@@ -111,3 +111,8 @@
   value:
     gorouter: nil
 
+# Avoid conflict with https://github.com/cloudfoundry/cf-deployment/pull/1141/files and use an alternate port
+- type: replace
+  path: /instance_groups/name=router-main/jobs/name=gorouter/properties/router/status?/tls?
+  value:
+    port: 9443

--- a/bosh/opsfiles/secureproxy.yml
+++ b/bosh/opsfiles/secureproxy.yml
@@ -92,3 +92,10 @@
 - type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/tls_port?
   value: 8443
+
+
+# Avoid conflict with https://github.com/cloudfoundry/cf-deployment/pull/1141/files and use an alternate port
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/status?/tls?
+  value:
+    port: 9443


### PR DESCRIPTION
## Changes proposed in this pull request:
- The new router health endpoint by default listens on 8443.  By luck, we happened to use this for secureproxy, so moving the health check to a different unused port
-
-

## security considerations
Adds a new health check for the routers
