### PR TITLE
Removed references to credhub for cells since it is not deployed

### DIFF
--- a/bosh/opsfiles/enable-cflinuxfs4.yml
+++ b/bosh/opsfiles/enable-cflinuxfs4.yml
@@ -1,71 +1,11 @@
 # This file is the midpoint to get cflinuxfs4 enabled 
+
+# Used to pull out credhub_tls certificate
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs4-rootfs-setup/properties/cflinuxfs4-rootfs/trusted_certs
   value:
     - ((diego_instance_identity_ca.ca))
     - ((uaa_ssl.ca))
 
-- type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/-
-  value:
-    name: cflinuxfs4-rootfs-setup
-    properties:
-      cflinuxfs4-rootfs:
-        trusted_certs:
-        - ((diego_instance_identity_ca.ca))
-        - ((uaa_ssl.ca))
-    release: cflinuxfs4
-- type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/name=rep/properties/diego/rep/preloaded_rootfses/-
-  value: cflinuxfs4:/var/vcap/packages/cflinuxfs4/rootfs.tar
 
-- type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/droplet_destinations/cflinuxfs3?
-  value: /home/vcap
-- type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/lifecycle_bundles/buildpack~1cflinuxfs3?
-  value: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
-- type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/name=cflinuxfs4:before
-  value:
-    description: Cloud Foundry Linux-based filesystem (Ubuntu 18.04)
-    name: cflinuxfs3
-- type: replace
-  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/diego/droplet_destinations/cflinuxfs3?
-  value: /home/vcap
-- type: replace
-  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/diego/lifecycle_bundles/buildpack~1cflinuxfs3?
-  value: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/diego/droplet_destinations/cflinuxfs3?
-  value: /home/vcap
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/diego/lifecycle_bundles/buildpack~1cflinuxfs3?
-  value: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/diego/droplet_destinations/cflinuxfs3?
-  value: /home/vcap
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/diego/lifecycle_bundles/buildpack~1cflinuxfs3?
-  value: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup?
-  value:
-    name: cflinuxfs3-rootfs-setup
-    properties:
-      cflinuxfs3-rootfs:
-        trusted_certs:
-        - ((diego_instance_identity_ca.ca))
-        - ((credhub_tls.ca))
-        - ((uaa_ssl.ca))
-    release: cflinuxfs3
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/rep/preloaded_rootfses/0:before
-  value: cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar
-- type: replace
-  path: /releases/name=cflinuxfs4:before
-  value:
-    name: cflinuxfs3
-    sha1: 5463400cd5490e9d847326668d504a8833cf3e4e
-    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.369.0
-    version: 0.369.0
+

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1088,6 +1088,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/diego-overcommit.yml
       - cf-manifests/bosh/opsfiles/scaling-production.yml
+      - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add ops file back to override the list of default trusted certs to remove credhub ca
- Otherwise, removed cflinuxfs3 overrides and added the customization of diego-platform-cells directly into that ops file
-

## security considerations
Continue to remove cflinuxfs3
