### PR TITLE
add opensearch CA to be trusted by gorouters

### DIFF
--- a/bosh/opsfiles/add-opensearch-ca.yml
+++ b/bosh/opsfiles/add-opensearch-ca.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?/-
+  value: ((/bosh/logs-opensearch/opensearch_ca.ca))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -82,6 +82,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/router-main-dev.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
       - cf-manifests/bosh/opsfiles/router-logstash-dev.yml
+      - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- add opensearch CA to be trusted by gorouters so that routes published by `route_registrar` can communicate with TLS enabled backend endpoints such as Opensearch Dashboards

## security considerations

We are adding the CA used to sign certificates for components of the Opensearch deployment to the overall trust store for the gorouters, so this is a meaningful security change. However, in a sense, it's a good change because it keeps the management of CAs/certificates for Opensearch unique to that deployment rather than using a CA that is shared by multiple deployments.
