### PR TITLE
fix to make slack-notification use the hardened image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1569,10 +1569,23 @@ resources:
   type: time
 
 resource_types:
-- name: slack-notification
-  type: docker-image
+- name: registry-image
+  type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
+- name: slack-notification
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: slack-notification-resource
+    aws_region: us-gov-west-1
+    tag: latest
 
 - name: bosh-deployment
   type: docker-image


### PR DESCRIPTION
## Changes proposed in this pull request:
- Modified pipeline to use the hardened image for the slack-notification resource
-
-

## security considerations
None