### PR TITLE
Scaling prod and patch for staging memory

### DIFF
--- a/bosh/opsfiles/diego-overcommit.yml
+++ b/bosh/opsfiles/diego-overcommit.yml
@@ -5,3 +5,7 @@
 - type: replace
   path: /instance_groups/name=diego-platform-cell/jobs/name=rep/properties/diego/executor?/memory_capacity_mb
   value: 50000
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/dea_next?/staging_memory_limit_mb
+  value: 2048

--- a/bosh/opsfiles/scaling-production.yml
+++ b/bosh/opsfiles/scaling-production.yml
@@ -91,7 +91,7 @@
 # diego platform (platform and customer)
 - type: replace
   path: /instance_groups/name=diego-cell/instances
-  value: 49
+  value: 52
 - type: replace
   path: /instance_groups/name=diego-cell/vm_type
   value: m5.2xlarge


### PR DESCRIPTION
## Changes proposed in this pull request:
- Scaling diego cells to 52
- Setting the default scaling memory to 2GB
-

## security considerations
None
