### PR TITLE
Add cg-ui dashboard to clients.yml

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -151,7 +151,7 @@
     authorized-grant-types: authorization_code,client_credentials,refresh_token
     autoapprove: true
     secret: ((cg-ui-client-secret))
-    scope: cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admin
+    scope: scim.me,openid,profile,uaa.user,cloud_controller.admin
     authorities: scim.userids,scim.invite,scim.read
     redirect-uri: https://cg-ui.((system_domain))/auth/login/callback
 

--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -151,7 +151,7 @@
     authorized-grant-types: authorization_code,client_credentials,refresh_token
     autoapprove: true
     secret: ((cg-ui-client-secret))
-    scope: cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admincloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admin
+    scope: cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admin
     authorities: scim.userids,scim.invite,scim.read
     redirect-uri: https://cg-ui.((system_domain))/auth/login/callback
 

--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -144,6 +144,17 @@
     redirect-uri: https://dashboard.((system_domain))/pp/v1/auth/sso_login_callback
     secret: ((stratos-client-secret))
 
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cg-ui?
+  value:
+    override: true
+    authorized-grant-types: authorization_code,client_credentials,refresh_token
+    autoapprove: true
+    secret: ((cg-ui-client-secret))
+    scope: cloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admincloud_controller.read,cloud_controller.admin_read_only,cloud_controller.global_auditor,cloud_controller.write,scim.me,openid,profile,uaa.user,cloud_controller.admin
+    authorities: scim.userids,scim.invite,scim.read
+    redirect-uri: https://cg-ui.((system_domain))/auth/login/callback
+
 # Update existing clients
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cf/access-token-validity

--- a/bosh/opsfiles/use-master-bosh-ca.yml
+++ b/bosh/opsfiles/use-master-bosh-ca.yml
@@ -248,6 +248,11 @@
 - type: replace
   path: /variables/-
   value: 
+    name: cg-ui-client-secret
+    type: password
+- type: replace
+  path: /variables/-
+  value: 
     name: sandbox-bot-client-secret
     type: password
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add new UAA client in order to deploy and evaluate `paas-admin` as per [documentation](https://github.com/alphagov/paas-admin?tab=readme-ov-file#prerequisites)

## security considerations
Clients.yml is currently deployed on every environment so this new client will be available in production as well.