### PR TITLE
fix cg-ui-client-secret var to be defined in correct opsfile

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -146,6 +146,12 @@
     secret: ((stratos-client-secret))
 
 - type: replace
+  path: /variables/-
+  value:
+    name: cg-ui-client-secret
+    type: password
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cg-ui?
   value:
     override: true
@@ -162,4 +168,4 @@
   value: 600
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cf/refresh-token-validity
-  value: 259200 
+  value: 259200

--- a/bosh/opsfiles/use-master-bosh-ca.yml
+++ b/bosh/opsfiles/use-master-bosh-ca.yml
@@ -212,82 +212,77 @@
 
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: broker-deployer-password
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: user-tester-password
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: uaa-extras-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: uaa-credentials-broker-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: uaa-client-audit-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: terraform-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: stratos-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
-    name: cg-ui-client-secret
-    type: password
-- type: replace
-  path: /variables/-
-  value: 
+  value:
     name: sandbox-bot-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: s3-broker-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: logsearch-firehose-ingestor-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: kibana-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: firehose-exporter-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: cf-exporter-client-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: cdn-broker-secret
     type: password
 - type: replace
   path: /variables/-
-  value: 
+  value:
     name: buildpack-notifier-client-secret
     type: password
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:

Fix #8080 since bosh/opsfiles/use-master-bosh-ca.yml opsfile is not actually used by the pipeline

## security considerations

No security issues, just moving definition of variable to happen in opsfile that is actually used
