### PR TITLE
Ops file to enable new cpu entitlement metris and keep old ones around

### DIFF
--- a/bosh/opsfiles/diego-cpu-entitlement.yml
+++ b/bosh/opsfiles/diego-cpu-entitlement.yml
@@ -1,0 +1,8 @@
+---
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/loggregator/app_metric_exclusion_filter
+
+- type: remove
+  path: /instance_groups/name=diego-platform-cell/jobs/name=rep/properties/loggregator/app_metric_exclusion_filter
+
+### This makes sure that absolute-cpu-entitlement is still emitting in addition to newer cpu_entitlement

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -83,6 +83,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/router-logstash.yml
       - cf-manifests/bosh/opsfiles/router-logstash-dev.yml
       - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
+      - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -586,6 +587,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
+      - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -1099,6 +1101,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
+      - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Enables this but also enables new cpu metrics https://github.com/cloudfoundry/cf-deployment/blob/develop/operations/use-absolute-cpu-entitlement.yml
- https://github.com/cloudfoundry/cf-deployment/pull/1164
-

## security considerations
None this metric is just getting improved for less math needed :) 