### PR TITLE
Switch Diego cells in staging to use newer r6i instances

### DIFF
--- a/bosh/opsfiles/scaling-staging.yml
+++ b/bosh/opsfiles/scaling-staging.yml
@@ -129,7 +129,7 @@
 # diego (platform and customer)
 - type: replace
   path: /instance_groups/name=diego-cell/vm_type
-  value: c5.2xlarge
+  value: r6i.2xlarge
 - type: replace
   path: /instance_groups/name=diego-cell/update?
   value:
@@ -137,7 +137,7 @@
     canaries: 11%
 - type: replace
   path: /instance_groups/name=diego-platform-cell/vm_type
-  value: c5.2xlarge
+  value: r6i.2xlarge
 
 # rotate-cc-database-key
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch Diego cells in staging to use newer r6i instances
- Step 2 will be to remove the `diego-overcommit.yml` which shouldn't be needed anymore.  
-

## security considerations
None
