### PR TITLE
Removing overcommit

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -574,7 +574,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/platform-cells.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/diego-dns.yml
-      - cf-manifests/bosh/opsfiles/diego-overcommit.yml
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- This change removes the use of `diego-overcommit.yml` from being used in staging by the pipeline
- Already deployed to r6i.2xlarge so we have 64gb of memory, the overcommit uses 50gb so we're losing access to 14GB currently.
- Part of https://github.com/cloud-gov/product/issues/2935

## security considerations
None
