### PR TITLE
Switching cell instance types for prod

### DIFF
--- a/bosh/opsfiles/diego-overcommit.yml
+++ b/bosh/opsfiles/diego-overcommit.yml
@@ -1,11 +1,3 @@
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/executor?/memory_capacity_mb
-  value: 50000
-
-- type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/name=rep/properties/diego/executor?/memory_capacity_mb
-  value: 50000
-
-- type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/dea_next?/staging_memory_limit_mb
   value: 2048

--- a/bosh/opsfiles/scaling-production.yml
+++ b/bosh/opsfiles/scaling-production.yml
@@ -28,7 +28,7 @@
   value: 6
 - type: replace
   path: /instance_groups/name=api/vm_type
-  value: t3.large
+  value: m6i.large
 
 # capi worker
 - type: replace
@@ -94,7 +94,7 @@
   value: 52
 - type: replace
   path: /instance_groups/name=diego-cell/vm_type
-  value: m5.2xlarge
+  value: r6i.2xlarge
 - type: replace
   path: /instance_groups/name=diego-cell/update?
   value:
@@ -102,7 +102,7 @@
     canaries: 3
 - type: replace
   path: /instance_groups/name=diego-platform-cell/vm_type
-  value: m5.2xlarge
+  value: r6i.2xlarge
 - type: replace
   path: /instance_groups/name=diego-platform-cell/instances
   value: 3


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch cells to use `r6i.2xlarge` which also means the overcommits can be removed since the physical memory will now be larger than the overcommit
- Switching the API vms to use non-burstable m6i to reduce observed cpu steal time.
- Part of https://github.com/cloud-gov/product/issues/2935

## security considerations
None
