### PR TITLE
Scale down prod

### DIFF
--- a/bosh/opsfiles/scaling-production.yml
+++ b/bosh/opsfiles/scaling-production.yml
@@ -91,7 +91,7 @@
 # diego platform (platform and customer)
 - type: replace
   path: /instance_groups/name=diego-cell/instances
-  value: 52
+  value: 40
 - type: replace
   path: /instance_groups/name=diego-cell/vm_type
   value: r6i.2xlarge

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -574,6 +574,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/platform-cells.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/diego-dns.yml
+      - cf-manifests/bosh/opsfiles/diego-overcommit.yml
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Diego cells are now deployed with r6i.2xlarge instances with the overcommit removed, meaning we have a surplus of 728GB
- Undo removal of ops file to put back in staging memory of 2GB back into Staging CF
- Part of https://github.com/cloud-gov/product/issues/2935

## security considerations
None
