### PR TITLE
We do not need to remove this all the time

### DIFF
--- a/bosh/opsfiles/router-logstash.yml
+++ b/bosh/opsfiles/router-logstash.yml
@@ -127,5 +127,3 @@
         value: "text/plain; charset=utf-8"
       - name: "X-Frame-Options"
         value: "DENY"
-      remove_headers:
-      - name: X-Frame-Options

--- a/bosh/opsfiles/router-main.yml
+++ b/bosh/opsfiles/router-main.yml
@@ -126,5 +126,3 @@
         value: "text/plain; charset=utf-8"
       - name: "X-Frame-Options"
         value: "DENY"
-      remove_headers:
-      - name: X-Frame-Options

--- a/bosh/opsfiles/secureproxy.yml
+++ b/bosh/opsfiles/secureproxy.yml
@@ -108,5 +108,3 @@
         value: "text/plain; charset=utf-8"
       - name: "X-Frame-Options"
         value: "DENY"
-      remove_headers:
-      - name: X-Frame-Options


### PR DESCRIPTION
## Changes proposed in this pull request:
- X frame is sometimes configurable but we should keep adding it if it's not there.

## security considerations
This was too strict so not removing the header if it already exists