### PR TITLE
Add autoscaler user for acceptance testing

### DIFF
--- a/bosh/opsfiles/use-master-bosh-ca.yml
+++ b/bosh/opsfiles/use-master-bosh-ca.yml
@@ -218,6 +218,11 @@
 - type: replace
   path: /variables/-
   value:
+    name: autoscaler-password
+    type: password
+- type: replace
+  path: /variables/-
+  value:
     name: user-tester-password
     type: password
 - type: replace

--- a/bosh/opsfiles/users.yml
+++ b/bosh/opsfiles/users.yml
@@ -13,3 +13,11 @@
     name: broker-deployer
     password: ((broker-deployer-password))
     groups: [openid, cloud_controller.admin]
+
+# Autoscaler user
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/scim/users/-
+  value:
+    name: autoscaler
+    password: ((autoscaler-password))
+    groups: [openid, cloud_controller.admin, scim.read, scim.write]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add autoscaler user for acceptance testing, following how `broker-deployer` does this similarly
- Part of https://github.com/cloud-gov/product/issues/2972
-

## security considerations
Password will be generated and stored by credhub
