### PR TITLE
Moving password creation for autoscaler user

### DIFF
--- a/bosh/opsfiles/use-master-bosh-ca.yml
+++ b/bosh/opsfiles/use-master-bosh-ca.yml
@@ -218,11 +218,6 @@
 - type: replace
   path: /variables/-
   value:
-    name: autoscaler-password
-    type: password
-- type: replace
-  path: /variables/-
-  value:
     name: user-tester-password
     type: password
 - type: replace

--- a/bosh/opsfiles/users.yml
+++ b/bosh/opsfiles/users.yml
@@ -21,3 +21,8 @@
     name: autoscaler
     password: ((autoscaler-password))
     groups: [openid, cloud_controller.admin, scim.read, scim.write]
+- type: replace
+  path: /variables/-
+  value:
+    name: autoscaler-password
+    type: password


### PR DESCRIPTION
## Changes proposed in this pull request:
- Found that `use-master-bosh-ca.yml` isn't used as an ops file in the pipeline
- Moving password creation for autoscaler user to `users.yml`
- Part of https://github.com/cloud-gov/product/issues/2972

## security considerations
None
