### PR TITLE
moving diego-platform-cell to 200GB disk

### DIFF
--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -9,7 +9,7 @@
     instances: 2
     vm_type: small-highmem
     vm_extensions:
-    - 100GB_ephemeral_disk
+    - 200GB_ephemeral_disk
     stemcell: default
     networks:
     - name: default


### PR DESCRIPTION
## Changes proposed in this pull request:
- Due to instance size changes - swap is consuming more disk so less is available to app instances

## security considerations
n/a
