### PR TITLE
Adding autoscaler certs to cf router trusted certs

### DIFF
--- a/bosh/opsfiles/add-autoscaler-ca.yml
+++ b/bosh/opsfiles/add-autoscaler-ca.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?/-
+  value: ((/bosh/app-autoscaler/app_autoscaler_ca_cert.ca))
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?/-
+  value: ((/bosh/app-autoscaler/metric_scraper_ca.ca))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -81,6 +81,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/router-main-dev.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
       - cf-manifests/bosh/opsfiles/router-logstash-dev.yml
+      - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
       - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       - cf-manifests/bosh/opsfiles/aggregate_drains.yml
@@ -586,6 +587,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
+      - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
@@ -1099,6 +1101,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
+      - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add autoscaler's CA certs to cf routers, need for route_registrar
- Part of https://github.com/cloud-gov/product/issues/2972
-

## security considerations
None, CAs stored/managed in Credhub
