### PR TITLE
Adding bosh dns entries for other deployments (ie autoscaler)

### DIFF
--- a/bosh/opsfiles/add-bosh-dns-other-deployments.yml
+++ b/bosh/opsfiles/add-bosh-dns-other-deployments.yml
@@ -1,0 +1,74 @@
+# Adds BOSH DNS lookup to autoscaler deployment so route-registrar can communicate with the routers over TLS:
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: app-autoscaler.apiserver.service.cf.internal
+    targets:
+    - deployment: app-autoscaler
+      domain: bosh
+      instance_group: apiserver
+      network: default
+      query: '*'
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: app-autoscaler.autoscalerscheduler.service.cf.internal
+    targets:
+    - deployment: app-autoscaler
+      domain: bosh
+      instance_group: scheduler
+      network: default
+      query: '*'
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: app-autoscaler.servicebroker.service.cf.internal
+    targets:
+    - deployment: app-autoscaler
+      domain: bosh
+      instance_group: apiserver
+      network: default
+      query: '*'
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: app-autoscaler.eventgenerator.service.cf.internal
+    targets:
+    - deployment: app-autoscaler
+      domain: bosh
+      instance_group: eventgenerator
+      network: default
+      query: '*'
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: app-autoscaler.scalingengine.service.cf.internal
+    targets:
+    - deployment: app-autoscaler
+      domain: bosh
+      instance_group: scalingengine
+      network: default
+      query: '*'
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: app-autoscaler.metricsforwarder.service.cf.internal
+    targets:
+    - deployment: app-autoscaler
+      domain: bosh
+      instance_group: metricsforwarder
+      network: default
+      query: '*'
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: app-autoscaler.operator.service.cf.internal
+    targets:
+    - deployment: app-autoscaler
+      domain: bosh
+      instance_group: operator
+      network: default
+      query: '*'
+
+# Other deployments (tbd) to go here:
+

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -82,6 +82,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/router-logstash.yml
       - cf-manifests/bosh/opsfiles/router-logstash-dev.yml
       - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
+      - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
       - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       - cf-manifests/bosh/opsfiles/aggregate_drains.yml
@@ -588,6 +589,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
       - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
+      - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
@@ -1102,6 +1104,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
       - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
+      - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds autoscaler's bosh dns entries so they are visible to the routers for route registration
- Part of https://github.com/cloud-gov/product/issues/2972
-

## security considerations
None, no secrets in play
