### PR TITLE
Switch clients to 12h refresh tokens

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -67,7 +67,7 @@
     authorized-grant-types: authorization_code,client_credentials
     authorities: scim.read,password.write,uaa.admin,uaa.resource
     access-token-validity: 600
-    refresh-token-validity: 259200
+    refresh-token-validity: 43200
     redirect-uri: https://account.((system_domain))/oauth/login
     name: Invite Users
     autoapprove: true
@@ -134,7 +134,7 @@
     scope: cloud_controller.read,oauth.approvals,openid,scim.userids
     authorized-grant-types: authorization_code,refresh_token
     access-token-validity: 600
-    refresh-token-validity: 259200
+    refresh-token-validity: 43200
     name: Logsearch
     redirect-uri: https://logs.((system_domain))/login
     autoapprove: true
@@ -149,7 +149,7 @@
     authorized-grant-types: authorization_code,client_credentials,refresh_token
     authorities: uaa.none
     access-token-validity: 600
-    refresh-token-validity: 259200
+    refresh-token-validity: 43200
     name: "Dashboard"
     autoapprove: true
     show-on-homepage: true
@@ -181,4 +181,4 @@
   value: 600
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cf/refresh-token-validity
-  value: 259200
+  value: 43200

--- a/bosh/opsfiles/pages-clients-dev.yml
+++ b/bosh/opsfiles/pages-clients-dev.yml
@@ -13,7 +13,7 @@
     authorized-grant-types: authorization_code,client_credentials
     authorities: groups.update,scim.read,scim.invite,scim.write
     access-token-validity: 600
-    refresh-token-validity: 259200
+    refresh-token-validity: 43200
     name: Pages
     autoapprove: true
     show-on-homepage: true

--- a/bosh/opsfiles/pages-clients-production.yml
+++ b/bosh/opsfiles/pages-clients-production.yml
@@ -13,7 +13,7 @@
     authorized-grant-types: authorization_code,client_credentials
     authorities: groups.update,scim.read,scim.invite,scim.write
     access-token-validity: 600
-    refresh-token-validity: 259200
+    refresh-token-validity: 43200
     name: Pages
     autoapprove: true
     show-on-homepage: true

--- a/bosh/opsfiles/pages-clients-staging.yml
+++ b/bosh/opsfiles/pages-clients-staging.yml
@@ -13,7 +13,7 @@
     authorized-grant-types: authorization_code,client_credentials
     authorities: groups.update,scim.read,scim.invite,scim.write
     access-token-validity: 600
-    refresh-token-validity: 259200
+    refresh-token-validity: 43200
     name: Pages
     autoapprove: true
     show-on-homepage: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch clients to 12h refresh tokens from 72h
- Story: https://github.com/cloud-gov/private/issues/1327
-

## security considerations
Requested by the compliance team
