### PR TITLE
Bump starlette version

### DIFF
--- a/ci/test-space-egress/requirements.txt
+++ b/ci/test-space-egress/requirements.txt
@@ -20,7 +20,7 @@ pyparsing==2.4.7
 regex==2021.8.28
 requests==2.32.2
 six==1.16.0
-starlette==0.36.2
+starlette==0.35.1
 tomli==1.2.1
 typing-extensions==3.10.0.2
 urllib3==1.26.18


### PR DESCRIPTION
## Changes proposed in this pull request:
- Solving for:

```
   The conflict is caused by:
   The user requested starlette==0.36.2
   fastapi 0.109.1 depends on starlette<0.36.0 and >=0.35.0
```
-
-

## security considerations
Bump back one of the dependencies
