### PR TITLE
Bumping typing-extensions version

### DIFF
--- a/ci/test-space-egress/requirements.txt
+++ b/ci/test-space-egress/requirements.txt
@@ -22,7 +22,7 @@ requests==2.32.2
 six==1.16.0
 starlette==0.35.1
 tomli==1.2.1
-typing-extensions==3.10.0.2
+typing-extensions==4.8.0
 urllib3==1.26.18
 userpath==1.7.0
 uvicorn==0.15.0


### PR DESCRIPTION
## Changes proposed in this pull request:
- Solving for:
```
   The conflict is caused by:
   The user requested typing-extensions==3.10.0.2
   fastapi 0.109.1 depends on typing-extensions>=4.8.0
```
-
-

## security considerations
None
