### PR TITLE
Remove redundant platform cell config

### DIFF
--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -225,19 +225,6 @@
     network: ((network_name))
     domain: bosh
 
-# Enable service discovery
-- type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/name=bosh-dns-adapter?
-  value:
-    name: bosh-dns-adapter
-    properties:
-      internal_domains: ["apps.internal."]
-      dnshttps:
-        client:
-          tls: ((cf_app_sd_client_tls))
-        server:
-          ca: ((cf_app_sd_server_tls.ca))
-    release: cf-networking
 - type: replace
   path: /instance_groups/name=diego-platform-cell/jobs/name=route_emitter/properties/internal_routes?
   value:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Values are already set correctly in the preceding `replace` block
- `ca: ((cf_app_sd_server_tls.ca))` did not match upstream but the ca value is the same for this and the correct variable
- https://github.com/cloud-gov/product/issues/3024

## security considerations
None, same end ca in force, conforms to upstream configuration
