### PR TITLE
Remove redundant platform diego cell property

### DIFF
--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -225,7 +225,3 @@
     network: ((network_name))
     domain: bosh
 
-- type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/name=route_emitter/properties/internal_routes?
-  value:
-    enabled: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- Values are already set correctly in the preceding `replace` block
- https://github.com/cloud-gov/product/issues/3024

## security considerations
None, same property was already set

