### PR TITLE
Remove redundant ops file

### DIFF
--- a/bosh/opsfiles/diego-dns.yml
+++ b/bosh/opsfiles/diego-dns.yml
@@ -1,3 +1,0 @@
-- type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/name=silk-cni/properties?/dns_servers
-  value: [169.254.0.2]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -65,7 +65,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
-      - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/scaling-development.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml
@@ -575,7 +574,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
-      - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/enable-cflinuxfs4.yml
@@ -1090,7 +1088,6 @@ jobs:
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
-      - cf-manifests/bosh/opsfiles/diego-dns.yml
       - cf-manifests/bosh/opsfiles/scaling-production.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/routing.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Values are already set in the `platform-cells.yml` ops file
- https://github.com/cloud-gov/product/issues/3024

## security considerations
None, the configuration exists in another ops file
