### PR TITLE
Remove redundant configuration for trusted_ca_certificates

### DIFF
--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -31,21 +31,8 @@
 - type: remove
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/credhub_api
 
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates
-  value:
-    - ((application_ca.certificate))
-    - ((uaa_ca.certificate))
-
 - type: remove
   path: /variables/name=uaa_clients_cc_service_key_client_secret
-
-####This shouldn't have ever been here?
-####- type: replace
-####  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/cflinuxfs3-rootfs/trusted_certs
-####  value:
-####    - ((diego_instance_identity_ca.ca))
-####    - ((uaa_ssl.ca))
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates


### PR DESCRIPTION
## Changes proposed in this pull request:
- Values are set twice, the last instance of `/instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates` won
- Removing commented out ref to cflinuxfs3
- https://github.com/cloud-gov/product/issues/3024

## security considerations
None, same certificates will be in force