### PR TITLE
Continue to split diego-cells

### DIFF
--- a/bosh/opsfiles/diego-cell-consumes-provides.yml
+++ b/bosh/opsfiles/diego-cell-consumes-provides.yml
@@ -1,0 +1,30 @@
+# Needed because the isolation segment(s) exist
+# Use distinct vxlan policy links for tenant cells
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/provides?/vpa
+  value: {as: vpa-tenant}
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=silk-daemon/consumes?/vpa
+  value: {from: vpa-tenant}
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=silk-cni/consumes?/vpa
+  value: {from: vpa-tenant}
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/consumes?/iptables
+  value: {from: iptables-tenant}
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=silk-daemon/consumes?/iptables
+  value: {from: iptables-tenant}
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=netmon/consumes?/iptables
+  value: {from: iptables-tenant}
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/provides?/iptables
+  value: {as: iptables-tenant}
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/consumes?/cni_config
+  value: {from: cni_config_tenant}
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=silk-cni/provides?/cni_config
+  value: {as: cni_config_tenant}
+

--- a/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
+++ b/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
@@ -1,0 +1,12 @@
+---
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/loggregator/app_metric_exclusion_filter
+
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/loggregator/app_metric_exclusion_filter
+
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/properties/loggregator/app_metric_exclusion_filter
+
+
+### This makes sure that absolute-cpu-entitlement is still emitting in addition to newer cpu_entitlement

--- a/bosh/opsfiles/diego-cpu-entitlement.yml
+++ b/bosh/opsfiles/diego-cpu-entitlement.yml
@@ -1,12 +1,4 @@
 ---
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/loggregator/app_metric_exclusion_filter
-
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/loggregator/app_metric_exclusion_filter
-
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/properties/loggregator/app_metric_exclusion_filter
 
 - type: remove
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/loggregator/app_metric_exclusion_filter

--- a/bosh/opsfiles/diego-rds-certs-diego-cell.yml
+++ b/bosh/opsfiles/diego-rds-certs-diego-cell.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=diego-platform-cell/jobs/name=cflinuxfs4-rootfs-setup/properties/cflinuxfs4-rootfs?/trusted_certs/-
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs4-rootfs-setup/properties/cflinuxfs4-rootfs?/trusted_certs/-
   value: |-
     # rds-ca-2015-root.pem - expired 3/2020 but still in use some instances
     -----BEGIN CERTIFICATE-----
@@ -256,5 +256,6 @@
     BFr6JV1x8VLbePblHd0V1MwDdRWeAwIwarWfOVdB1ijrwzjROzCwE0uBkHYUPr0Z
     vgwdtlsnwDw9TnjsBrTJkQ0aS8c0Ahl1
     -----END CERTIFICATE-----
+
 
 

--- a/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
@@ -1,0 +1,14 @@
+# This file exists to remove CredHub Secured Service Credential Delivery which
+# is now on by default in cf-deployment >=4.x.
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates
+  value:
+    - ((diego_instance_identity_ca.ca))
+    - ((uaa_ssl.ca))
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs4-rootfs-setup/properties/cflinuxfs4-rootfs/trusted_certs
+  value:
+    - ((diego_instance_identity_ca.ca))
+    - ((uaa_ssl.ca))

--- a/bosh/opsfiles/disable-secure-service-credentials.yml
+++ b/bosh/opsfiles/disable-secure-service-credentials.yml
@@ -34,14 +34,3 @@
 - type: remove
   path: /variables/name=uaa_clients_cc_service_key_client_secret
 
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/trusted_ca_certificates
-  value:
-    - ((diego_instance_identity_ca.ca))
-    - ((uaa_ssl.ca))
-
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs4-rootfs-setup/properties/cflinuxfs4-rootfs/trusted_certs
-  value:
-    - ((diego_instance_identity_ca.ca))
-    - ((uaa_ssl.ca))

--- a/bosh/opsfiles/log-levels-diego-cell.yml
+++ b/bosh/opsfiles/log-levels-diego-cell.yml
@@ -1,0 +1,11 @@
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/log_level?
+  value: error
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/rep/log_level?
+  value: error
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/diego/route_emitter/log_level?
+  value: error

--- a/bosh/opsfiles/log-levels.yml
+++ b/bosh/opsfiles/log-levels.yml
@@ -1,15 +1,3 @@
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/log_level?
-  value: error
-
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/rep/log_level?
-  value: error
-
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/diego/route_emitter/log_level?
-  value: error
-
-- type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/security_event_logging?/enabled
   value: true

--- a/bosh/opsfiles/meta-data-v2-diego-cell.yml
+++ b/bosh/opsfiles/meta-data-v2-diego-cell.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=diego-cell/vm_extensions/-
+  value: meta-data-v2

--- a/bosh/opsfiles/meta-data-v2.yml
+++ b/bosh/opsfiles/meta-data-v2.yml
@@ -1,6 +1,3 @@
 - type: replace
-  path: /instance_groups/name=diego-cell/vm_extensions/-
-  value: meta-data-v2
-- type: replace
   path: /instance_groups/name=diego-platform-cell/vm_extensions/-
   value: meta-data-v2

--- a/bosh/opsfiles/platform-cells.yml
+++ b/bosh/opsfiles/platform-cells.yml
@@ -186,34 +186,6 @@
   path: /instance_groups/name=diego-platform-cell/jobs/name=rep/properties/diego/rep/placement_tags?/-
   value: platform
 
-# Use distinct vxlan policy links for tenant cells
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/provides?/vpa
-  value: {as: vpa-tenant}
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=silk-daemon/consumes?/vpa
-  value: {from: vpa-tenant}
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=silk-cni/consumes?/vpa
-  value: {from: vpa-tenant}
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/consumes?/iptables
-  value: {from: iptables-tenant}
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=silk-daemon/consumes?/iptables
-  value: {from: iptables-tenant}
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=netmon/consumes?/iptables
-  value: {from: iptables-tenant}
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=garden/provides?/iptables
-  value: {as: iptables-tenant}
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/consumes?/cni_config
-  value: {from: cni_config_tenant}
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=silk-cni/provides?/cni_config
-  value: {as: cni_config_tenant}
 
 # Add platform cells to DNS aliases
 - type: replace

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -62,19 +62,24 @@ jobs:
       - cf-manifests/bosh/opsfiles/encryption.yml
       - cf-manifests/bosh/opsfiles/sql.yml
       - cf-manifests/bosh/opsfiles/log-levels.yml
+      - cf-manifests/bosh/opsfiles/log-levels-diego-cell.yml
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
+      - cf-manifests/bosh/opsfiles/diego-cell-consumes-provides.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/scaling-development.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
+      - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
       - cf-manifests/bosh/opsfiles/content-security-policy.yml
       - cf-manifests/bosh/opsfiles/loggregator.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
+      - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-main-dev.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
@@ -83,6 +88,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
       - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
+      - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
       - cf-manifests/bosh/opsfiles/aggregate_drains.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
@@ -570,23 +576,29 @@ jobs:
       - cf-manifests/bosh/opsfiles/encryption.yml
       - cf-manifests/bosh/opsfiles/sql.yml
       - cf-manifests/bosh/opsfiles/log-levels.yml
+      - cf-manifests/bosh/opsfiles/log-levels-diego-cell.yml
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
+      - cf-manifests/bosh/opsfiles/diego-cell-consumes-provides.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/scaling-staging.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
+      - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
       - cf-manifests/bosh/opsfiles/loggregator.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
+      - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
       - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
       - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
+      - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -1083,23 +1095,29 @@ jobs:
       - cf-manifests/bosh/opsfiles/encryption.yml
       - cf-manifests/bosh/opsfiles/sql.yml
       - cf-manifests/bosh/opsfiles/log-levels.yml
+      - cf-manifests/bosh/opsfiles/log-levels-diego-cell.yml
       - cf-manifests/bosh/opsfiles/instance-profiles.yml
       - cf-manifests/bosh/opsfiles/platform-cells.yml
+      - cf-manifests/bosh/opsfiles/diego-cell-consumes-provides.yml
       - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
       - cf-manifests/bosh/opsfiles/scaling-production.yml
       - cf-manifests/bosh/opsfiles/cf-networking.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs.yml
+      - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
       - cf-manifests/bosh/opsfiles/loggregator.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2.yml
+      - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
       - cf-manifests/bosh/opsfiles/router-logstash.yml
       - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
       - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
+      - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Splitting diego-cell changes into their own discreet ops files so they can be templated for iso-seg creation
- https://github.com/cloud-gov/product/issues/3024

## security considerations
None, should result in no-op deploy
