### PR TITLE
Have isolation segment configuration use names

### DIFF
--- a/ci/create-diego-cell-iso-seg.sh
+++ b/ci/create-diego-cell-iso-seg.sh
@@ -79,7 +79,7 @@ EOF
 done
 
 ## Either return the iso-seg file or a comment only file so "bosh deploy" will work in the main pipeline
-if [ -z "$ISO_SEG_NAMES" ]; then
+if [ -n "$ISO_SEG_NAMES" ]; then
   cp  diego-cell-iso-seg.yml diego-cell-iso-seg/diego-cell-iso-seg.yml
 else
   cat > diego-cell-iso-seg/diego-cell-iso-seg.yml << EOF

--- a/ci/create-diego-cell-iso-seg.sh
+++ b/ci/create-diego-cell-iso-seg.sh
@@ -27,7 +27,7 @@ for iso_seg_name in $ISO_SEG_NAMES; do
   echo "Creating isolation segment ${iso_seg_name}"...
 
   ## Create ops file header - Always start with the instance group declaration
-  cat > diego-cell-iso-seg${iso_seg_name}-header.yml <<EOF
+  cat > diego-cell-iso-seg-${iso_seg_name}-header.yml <<EOF
 
 # Add iso seg ${iso_seg_name} instance group
 - type: replace
@@ -36,46 +36,46 @@ for iso_seg_name in $ISO_SEG_NAMES; do
 EOF
 
   ## Create ops file body - replace name of instance group, swap out provides/consumes values and indent 4 spaces
-  sed "s/name: diego-cell/name: diego-cell-iso-seg${iso_seg_name}/" diego-cell_raw.yml > sed1.yml
-  sed "s/iptables-tenant/iptables-iso-seg${iso_seg_name}/" sed1.yml > sed2.yml
-  sed "s/cni_config_tenant/cni_config_iso-seg${iso_seg_name}/" sed2.yml > sed3.yml
-  sed "s/vpa-tenant/vpa-iso-seg${iso_seg_name}/" sed3.yml > sed4.yml
-  sed 's/^/    /' sed4.yml > diego-cell_indented-iso-seg${iso_seg_name}.yml
+  sed "s/name: diego-cell/name: diego-cell-iso-seg-${iso_seg_name}/" diego-cell_raw.yml > sed1.yml
+  sed "s/iptables-tenant/iptables-iso-seg-${iso_seg_name}/" sed1.yml > sed2.yml
+  sed "s/cni_config_tenant/cni_config_iso-seg-${iso_seg_name}/" sed2.yml > sed3.yml
+  sed "s/vpa-tenant/vpa-iso-seg-${iso_seg_name}/" sed3.yml > sed4.yml
+  sed 's/^/    /' sed4.yml > diego-cell_indented-iso-seg-${iso_seg_name}.yml
 
   ## Create ops file footer - All the "replace" that can only be run once the instance group exists (order matters)
-  cat > diego-cell-iso-seg${iso_seg_name}-footer.yml <<EOF
+  cat > diego-cell-iso-seg-${iso_seg_name}-footer.yml <<EOF
 
 # Add iso seg ${iso_seg_name} placement tag
 - type: replace
-  path: /instance_groups/name=diego-cell-iso-seg${iso_seg_name}/jobs/name=rep/properties/diego/rep/placement_tags?/-
-  value: diego-cell-iso-seg${iso_seg_name}
+  path: /instance_groups/name=diego-cell-iso-seg-${iso_seg_name}/jobs/name=rep/properties/diego/rep/placement_tags?/-
+  value: diego-cell-iso-seg-${iso_seg_name}
 
 # Add iso seg ${iso_seg_name} to DNS aliases
 - type: replace
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=_.cell.service.cf.internal/targets/-
   value:
     query: '_'
-    instance_group: diego-cell-iso-seg${iso_seg_name}
+    instance_group: diego-cell-iso-seg-${iso_seg_name}
     deployment: ((deployment_name))
     network: ((network_name))
     domain: bosh
 
 # Set default instance type since the one upstream has doesn't exists. Override this in scaling-*.yml
 - type: replace
-  path: /instance_groups/name=diego-cell-iso-seg${iso_seg_name}/vm_type
+  path: /instance_groups/name=diego-cell-iso-seg-${iso_seg_name}/vm_type
   value: t3.xlarge
 
 # Start with 2 instances.  Override this in scaling-*.yml
 - type: replace
-  path: /instance_groups/name=diego-cell-iso-seg${iso_seg_name}/instances
+  path: /instance_groups/name=diego-cell-iso-seg-${iso_seg_name}/instances
   value: 2
 EOF
 
   ## Append the header, main, and footer for this iso-seg
-  cat diego-cell-iso-seg${iso_seg_name}-header.yml diego-cell_indented-iso-seg${iso_seg_name}.yml diego-cell-iso-seg${iso_seg_name}-footer.yml > diego-cell-iso-seg${iso_seg_name}.yml
+  cat diego-cell-iso-seg-${iso_seg_name}-header.yml diego-cell_indented-iso-seg-${iso_seg_name}.yml diego-cell-iso-seg-${iso_seg_name}-footer.yml > diego-cell-iso-seg-${iso_seg_name}.yml
 
   ## Merge this iso-seg into one file which will have all of them at the end of the loop
-  cat diego-cell-iso-seg${iso_seg_name}.yml >> diego-cell-iso-seg.yml
+  cat diego-cell-iso-seg-${iso_seg_name}.yml >> diego-cell-iso-seg.yml
 done
 
 ## Either return the iso-seg file or a comment only file so "bosh deploy" will work in the main pipeline

--- a/ci/create-diego-cell-iso-seg.sh
+++ b/ci/create-diego-cell-iso-seg.sh
@@ -5,6 +5,7 @@ set -eux
 ## Extract current base configuration for the diego-cell instance group from upstream and apply custom ops files 
 ## NOTE: These ops files can only contain remove/replace for the diego-cell instance group for this to work in the future
 
+echo "Creating isolation segments for: ${ISO_SEG_NAMES}"...
 
 ## Create the starting point of a configured diego-cell for cg (minus scaling-*.ymls)
 bosh int \
@@ -20,68 +21,72 @@ bosh int \
 
 
 ## Loop through and create a single iso seg ops file, intermediate files aren't deleted for debugging
-for (( iso_seg_number = 1; iso_seg_number <= $NUMBER_OF_ISO_SEGS; iso_seg_number++ ))
-do
+
+for iso_seg_name in $ISO_SEG_NAMES; do
+
+  echo "Creating isolation segment ${iso_seg_name}"...
 
   ## Create ops file header - Always start with the instance group declaration
-  cat > diego-cell-iso-seg${iso_seg_number}-header.yml <<EOF
+  cat > diego-cell-iso-seg${iso_seg_name}-header.yml <<EOF
 
-# Add iso seg ${iso_seg_number} instance group
+# Add iso seg ${iso_seg_name} instance group
 - type: replace
   path: /instance_groups/name=diego-cell:after
   value:
 EOF
 
   ## Create ops file body - replace name of instance group, swap out provides/consumes values and indent 4 spaces
-  sed "s/name: diego-cell/name: diego-cell-iso-seg${iso_seg_number}/" diego-cell_raw.yml > sed1.yml
-  sed "s/iptables-tenant/iptables-iso-seg${iso_seg_number}/" sed1.yml > sed2.yml
-  sed "s/cni_config_tenant/cni_config_iso-seg${iso_seg_number}/" sed2.yml > sed3.yml
-  sed "s/vpa-tenant/vpa-iso-seg${iso_seg_number}/" sed3.yml > sed4.yml
-  sed 's/^/    /' sed4.yml > diego-cell_indented-iso-seg${iso_seg_number}.yml
+  sed "s/name: diego-cell/name: diego-cell-iso-seg${iso_seg_name}/" diego-cell_raw.yml > sed1.yml
+  sed "s/iptables-tenant/iptables-iso-seg${iso_seg_name}/" sed1.yml > sed2.yml
+  sed "s/cni_config_tenant/cni_config_iso-seg${iso_seg_name}/" sed2.yml > sed3.yml
+  sed "s/vpa-tenant/vpa-iso-seg${iso_seg_name}/" sed3.yml > sed4.yml
+  sed 's/^/    /' sed4.yml > diego-cell_indented-iso-seg${iso_seg_name}.yml
 
   ## Create ops file footer - All the "replace" that can only be run once the instance group exists (order matters)
-  cat > diego-cell-iso-seg${iso_seg_number}-footer.yml <<EOF
+  cat > diego-cell-iso-seg${iso_seg_name}-footer.yml <<EOF
 
-# Add iso seg ${iso_seg_number} placement tag
+# Add iso seg ${iso_seg_name} placement tag
 - type: replace
-  path: /instance_groups/name=diego-cell-iso-seg${iso_seg_number}/jobs/name=rep/properties/diego/rep/placement_tags?/-
-  value: diego-cell-iso-seg${iso_seg_number}
+  path: /instance_groups/name=diego-cell-iso-seg${iso_seg_name}/jobs/name=rep/properties/diego/rep/placement_tags?/-
+  value: diego-cell-iso-seg${iso_seg_name}
 
-# Add iso seg ${iso_seg_number} to DNS aliases
+# Add iso seg ${iso_seg_name} to DNS aliases
 - type: replace
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=_.cell.service.cf.internal/targets/-
   value:
     query: '_'
-    instance_group: diego-cell-iso-seg${iso_seg_number}
+    instance_group: diego-cell-iso-seg${iso_seg_name}
     deployment: ((deployment_name))
     network: ((network_name))
     domain: bosh
 
 # Set default instance type since the one upstream has doesn't exists. Override this in scaling-*.yml
 - type: replace
-  path: /instance_groups/name=diego-cell-iso-seg${iso_seg_number}/vm_type
+  path: /instance_groups/name=diego-cell-iso-seg${iso_seg_name}/vm_type
   value: t3.xlarge
 
 # Start with 2 instances.  Override this in scaling-*.yml
 - type: replace
-  path: /instance_groups/name=diego-cell-iso-seg${iso_seg_number}/instances
+  path: /instance_groups/name=diego-cell-iso-seg${iso_seg_name}/instances
   value: 2
 EOF
 
   ## Append the header, main, and footer for this iso-seg
-  cat diego-cell-iso-seg${iso_seg_number}-header.yml diego-cell_indented-iso-seg${iso_seg_number}.yml diego-cell-iso-seg${iso_seg_number}-footer.yml > diego-cell-iso-seg${iso_seg_number}.yml
+  cat diego-cell-iso-seg${iso_seg_name}-header.yml diego-cell_indented-iso-seg${iso_seg_name}.yml diego-cell-iso-seg${iso_seg_name}-footer.yml > diego-cell-iso-seg${iso_seg_name}.yml
 
   ## Merge this iso-seg into one file which will have all of them at the end of the loop
-  cat diego-cell-iso-seg${iso_seg_number}.yml >> diego-cell-iso-seg.yml
+  cat diego-cell-iso-seg${iso_seg_name}.yml >> diego-cell-iso-seg.yml
 done
 
 ## Either return the iso-seg file or a comment only file so "bosh deploy" will work in the main pipeline
-if [ "$NUMBER_OF_ISO_SEGS" -gt 0 ]; then
+if [ -z "$ISO_SEG_NAMES" ]; then
   cp  diego-cell-iso-seg.yml diego-cell-iso-seg/diego-cell-iso-seg.yml
 else
   cat > diego-cell-iso-seg/diego-cell-iso-seg.yml << EOF
 # Intentionally left blank
 EOF
 fi
+
+echo "Final iso seg ops file written to diego-cell-iso-seg/diego-cell-iso-seg.yml"
 
 ## return: diego-cell-iso-seg/diego-cell-iso-seg.yml

--- a/ci/create-diego-cell-iso-seg.sh
+++ b/ci/create-diego-cell-iso-seg.sh
@@ -80,13 +80,14 @@ done
 
 ## Either return the iso-seg file or a comment only file so "bosh deploy" will work in the main pipeline
 if [ -n "$ISO_SEG_NAMES" ]; then
+  echo "Returing iso seg ops file for ${ISO_SEG_NAMES}..."
   cp  diego-cell-iso-seg.yml diego-cell-iso-seg/diego-cell-iso-seg.yml
 else
+  echo "Returing blank iso seg ops file..."
   cat > diego-cell-iso-seg/diego-cell-iso-seg.yml << EOF
 # Intentionally left blank
 EOF
 fi
 
 echo "Final iso seg ops file written to diego-cell-iso-seg/diego-cell-iso-seg.yml"
-
 ## return: diego-cell-iso-seg/diego-cell-iso-seg.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
   - task: diego-cell-iso-seg
     file: cf-manifests/ci/create-diego-cell-iso-seg.yml
     params:
-      NUMBER_OF_ISO_SEGS: ((number_of_iso_segs_development))    # Value in credhub
+      ISO_SEG_NAMES: "" #((names_of_iso_segs_development))    # Value in credhub
   - put: cf-deployment-development
     params: &deploy-params
       manifest: cf-deployment/cf-deployment.yml
@@ -556,7 +556,7 @@ jobs:
   - task: diego-cell-iso-seg
     file: cf-manifests/ci/create-diego-cell-iso-seg.yml
     params:
-      NUMBER_OF_ISO_SEGS: ((number_of_iso_segs_staging))    # Value in credhub
+      ISO_SEG_NAMES: "" #((names_of_iso_segs_staging))    # Value in credhub
   - put: cf-deployment-staging
     params:
       <<: *deploy-params
@@ -1081,7 +1081,7 @@ jobs:
   - task: diego-cell-iso-seg
     file: cf-manifests/ci/create-diego-cell-iso-seg.yml
     params:
-      NUMBER_OF_ISO_SEGS: ((number_of_iso_segs_production))    # Value in credhub
+      ISO_SEG_NAMES: "" #((names_of_iso_segs_production))    # Value in credhub
   - put: cf-deployment-production
     params: &prod-deploy-params
       <<: *deploy-params
@@ -1188,7 +1188,7 @@ jobs:
   - task: diego-cell-iso-seg
     file: cf-manifests/ci/create-diego-cell-iso-seg.yml
     params:
-      NUMBER_OF_ISO_SEGS: ((number_of_iso_segs_production))    # Value in credhub
+      ISO_SEG_NAMES: "" #((names_of_iso_segs_production))    # Value in credhub
   - put: cf-deployment-production
     params:
       <<: *prod-deploy-params


### PR DESCRIPTION
## Changes proposed in this pull request:
- Using names instead of incremental counter to allow for easier deletion of isolation segments
- Will update internal-docs separately with new maintenance mechanism
- Credhub variables are set, but commented out in pipeline.yml, not allowed to use empty strings in credhub variables.  Once this feature is used, remove the hard coded "" and use the credhub variable currently comment out for `ISO_SEG_NAMES`
- Part of https://github.com/cloud-gov/product/issues/3024

## security considerations
None
