### PR TITLE
remove io stemcell resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1743,15 +1743,6 @@ resource_types:
     aws_region: us-gov-west-1
     tag: latest
 
-- name: bosh-io-stemcell
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: bosh-io-release-resource
-    aws_region: us-gov-west-1
-    tag: latest
-
 groups:
 - name: all
   jobs:


### PR DESCRIPTION
## Changes proposed in this pull request:
- This is the wrong hardened image for this resource. Reverting back to concourses default image for now.

## security considerations
Fixes reference to incorrect image
