### PR TITLE
Ops file to pin capi for now

### DIFF
--- a/bosh/opsfiles/pin-capi.yml
+++ b/bosh/opsfiles/pin-capi.yml
@@ -1,0 +1,18 @@
+# Pin CAPI because of valkey
+- type: replace
+  path: /releases/name=capi
+  value:
+    name: capi
+    version: 1.183.0
+    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.183.0
+    sha1: fceb5095f6ffc975fe12e0cc36daca00a3cf4db4
+
+# Switch to Redis
+- type: remove
+  path: /instance_groups/name=api/jobs/name=valkey
+
+- type: replace
+  path: /instance_groups/name=api/jobs/-
+  value:
+    name: redis
+    release: capi

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -102,6 +102,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
       - cf-manifests/bosh/opsfiles/aggregate_drains.yml
+      - cf-manifests/bosh/opsfiles/pin-capi.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
@@ -642,6 +643,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
+      - cf-manifests/bosh/opsfiles/pin-capi.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
@@ -1191,6 +1193,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement.yml
       - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
+      - cf-manifests/bosh/opsfiles/pin-capi.yml
       vars_files:
       - cf-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- We found an issue with valkey being replaced by redis
- Pin capi and use redis instead

## security considerations
None