### PR TITLE
Adding new S3 ranges to trusted local asg

### DIFF
--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -181,41 +181,16 @@ resource "cloudfoundry_asg" "trusted_local_networks" {
     ports       = "443"
   }
   # S3 Gateway access
-  rule {
+  dynamic "rule" {
+
+    for_each = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs
+    iterator = rule
+
     protocol    = "tcp"
     description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_1
+    destination = rule.value
     ports       = "443"
   }
-  
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_2
-    ports       = "443"
-  }
-
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_3
-    ports       = "443"
-  }
-
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_4
-    ports       = "443"
-  }
-
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_5
-    ports       = "443"
-  }  
-
 }
 
 # New trusted networks asg to apply to spaces individually, not globally.
@@ -289,38 +264,14 @@ resource "cloudfoundry_asg" "trusted_local_networks_egress" {
     ports       = "443"
   }
   # S3 Gateway access
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_1
-    ports       = "443"
-  }
+  dynamic "rule" {
 
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_2
-    ports       = "443"
-  }
+    for_each = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs
+    iterator = rule
 
-  rule {
     protocol    = "tcp"
     description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_3
-    ports       = "443"
-  }
-
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_4
-    ports       = "443"
-  }
-
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS S3 Gateway"
-    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_5
+    destination = rule.value
     ports       = "443"
   }
 }

--- a/terraform/stack/asg.tf
+++ b/terraform/stack/asg.tf
@@ -194,7 +194,28 @@ resource "cloudfoundry_asg" "trusted_local_networks" {
     destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_2
     ports       = "443"
   }
- 
+
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_3
+    ports       = "443"
+  }
+
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_4
+    ports       = "443"
+  }
+
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_5
+    ports       = "443"
+  }  
+
 }
 
 # New trusted networks asg to apply to spaces individually, not globally.
@@ -279,6 +300,27 @@ resource "cloudfoundry_asg" "trusted_local_networks_egress" {
     protocol    = "tcp"
     description = "Allow access to AWS S3 Gateway"
     destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_2
+    ports       = "443"
+  }
+
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_3
+    ports       = "443"
+  }
+
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_4
+    ports       = "443"
+  }
+
+  rule {
+    protocol    = "tcp"
+    description = "Allow access to AWS S3 Gateway"
+    destination = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidr_5
     ports       = "443"
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add 3 additional ip cidr ranges that s3 traffic is allowed outbound for to the trusted local and trusted local egress CF application security groups.
- Consumes outputs from cg-provision's [terraform/stacks/main/outputs.tf](https://github.com/cloud-gov/cg-provision/compare/s3asg?expand=1#diff-cdc1953ac1662a48e0f998d9e4aa5113fc4376bdff70079d426cae8f556abfa0)
- Related to https://github.com/cloud-gov/cg-provision/pull/1749

## security considerations
Requires application owners to restart or restage their apps to pick up additional s3 ip cidr ranges
