### PR TITLE
Require rds ssl for silk and policy components

### DIFF
--- a/bosh/opsfiles/rds-ca.yml
+++ b/bosh/opsfiles/rds-ca.yml
@@ -1,0 +1,99 @@
+### Enable requirement of SSL for silk-controller
+
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/require_ssl?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/ca_cert?
+  value: |+
+    # Amazon RDS us-gov-west-1 Root CA RSA4096 G1 expires May2121
+    -----BEGIN CERTIFICATE-----
+    MIIGBzCCA++gAwIBAgIRAOzQCoOR21YG2noWOfFcuNIwDQYJKoZIhvcNAQEMBQAw
+    gZsxCzAJBgNVBAYTAlVTMSIwIAYDVQQKDBlBbWF6b24gV2ViIFNlcnZpY2VzLCBJ
+    bmMuMRMwEQYDVQQLDApBbWF6b24gUkRTMQswCQYDVQQIDAJXQTE0MDIGA1UEAwwr
+    QW1hem9uIFJEUyB1cy1nb3Ytd2VzdC0xIFJvb3QgQ0EgUlNBNDA5NiBHMTEQMA4G
+    A1UEBwwHU2VhdHRsZTAgFw0yMTA1MjYyMTQ0MzlaGA8yMTIxMDUyNjIyNDQzOVow
+    gZsxCzAJBgNVBAYTAlVTMSIwIAYDVQQKDBlBbWF6b24gV2ViIFNlcnZpY2VzLCBJ
+    bmMuMRMwEQYDVQQLDApBbWF6b24gUkRTMQswCQYDVQQIDAJXQTE0MDIGA1UEAwwr
+    QW1hem9uIFJEUyB1cy1nb3Ytd2VzdC0xIFJvb3QgQ0EgUlNBNDA5NiBHMTEQMA4G
+    A1UEBwwHU2VhdHRsZTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANwY
+    M2iZdnnlMutI9nfn2fWBICAQHWmMmpPmtSka/ziBFyaCxkHDF8RLmooW+GLe+FEF
+    9CQKSVqRa7X5AFiqRFF1KvgxWvazawyScuw88JW6Eqhaw0Rlm2p1Iow3TE8FSCDo
+    Is1vEV3Brbf26CMiXbqI+aCuTOy0fjRzjl5igViTgZxt2ZXOwyKkF+2T8LQp4b4F
+    Mh85Ctw1An1DhAemsc3SmcYnPKyFUP90DxGuTjFtfNR01GbBtVYwVvOBgIJe59Zs
+    OWcEFOO2mU53Ik6oKcLYu4+PmE5aDvQewb6bkQZchClb7Eg0BPYekWwTPsKUTS3H
+    bgdwVxgzjdAdU9fvaaoQmS9xdHWlonKq8CubJdLUduV3WVmDAg7MQgiT3p8JF9W2
+    KbQpUbYxqd7j9OIe3IS3rVPwYA8PVh1hUJ+OBLw61sbGRAuN3H+B1DlJh1smg6bR
+    g9W+oLRzfjZa32EzFmaQIxtgRfiyjxB/vqAHdl5zPou30X1CyRYquS870O02bvTN
+    zzWSOfRY4KPmS1YFVsN+m+R4+hSUOAE//bJ25ACP9oDO5w9NWkAux4e0UUAuWCra
+    jRROYN2J0KCogdru5G7lOQerD12zi3C2iibty6ou4tQX+MIKMMUVq8cfUH7oKv/R
+    8mL5PV/NUsgO248llo0lr9QBwQKdiw17wCxFR+8vAgMBAAGjQjBAMA8GA1UdEwEB
+    /wQFMAMBAf8wHQYDVR0OBBYEFPDYnx2xYIPDDAEjb6UcF29I6DgKMA4GA1UdDwEB
+    /wQEAwIBhjANBgkqhkiG9w0BAQwFAAOCAgEANTrAGs/GpXCADAwMGlrjXTdohp+p
+    CIp3gbnryVYZBXvO+f8hjJ8bHk0D/DiBrkjE8o0IpNaAadOZa+WvTNMsanPmGf1A
+    kD0vA9nm4gwEhBbzj9HRYX+dIhZhVWny9Kugm80s0h0hvbwTakUPOdMqkz6wn+xx
+    Owh7AIwaC5TTCsQyKlv5rjVblvU1XFgBf3Pf3wvMAfjDoAEPTXER/9mLVbXe+EmW
+    osP1JmgyDd+0WQFVK/LEDW81L5hsV5JvthAAFhGVtRw9ko5Ep28+EQUJE1wmLTdL
+    PyjB/KfJrTMDq94WolzFv4JpUStHbclkKlXtigjKeiYZ5Yvo+vLMSkXemccSfYn7
+    vdaUFD5vqWXvM4xhiYRq/tigw2E1bjmyd9L3XD7XalufZtMGWn7zT8HMPP+/Lch1
+    JjZ9LL2Y99VIqhoHcuSa95FtLpYDRQ28K03uwqxqFnOQLyPVmYwsaHKnmmwaZDjF
+    K1XxLVRLGRWvKEuSoWrsGcs3ehoxX4Knz/BaJzr/ioU1VnItj53tmOSJO0eMA6k+
+    egaVEb0FTa2F5xeLCKjgfDDWMz3v0TdL+kt+9z0THMlPWfOzd1C35ZzSIcTcRj22
+    SAzsL0t5ZTI4XvoPFF8dga78/KsBRolqdPjs0UzdlKhwh1ADOkTRgLOaaidMEgsT
+    JS/rbzD4FPbvc/g=
+    -----END CERTIFICATE-----
+
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/skip_hostname_validation?
+  value: true
+
+### Enable requirement of SSL for policy-server
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/require_ssl?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/ca_cert?
+  value: |+
+    # Amazon RDS us-gov-west-1 Root CA RSA4096 G1 expires May2121
+    -----BEGIN CERTIFICATE-----
+    MIIGBzCCA++gAwIBAgIRAOzQCoOR21YG2noWOfFcuNIwDQYJKoZIhvcNAQEMBQAw
+    gZsxCzAJBgNVBAYTAlVTMSIwIAYDVQQKDBlBbWF6b24gV2ViIFNlcnZpY2VzLCBJ
+    bmMuMRMwEQYDVQQLDApBbWF6b24gUkRTMQswCQYDVQQIDAJXQTE0MDIGA1UEAwwr
+    QW1hem9uIFJEUyB1cy1nb3Ytd2VzdC0xIFJvb3QgQ0EgUlNBNDA5NiBHMTEQMA4G
+    A1UEBwwHU2VhdHRsZTAgFw0yMTA1MjYyMTQ0MzlaGA8yMTIxMDUyNjIyNDQzOVow
+    gZsxCzAJBgNVBAYTAlVTMSIwIAYDVQQKDBlBbWF6b24gV2ViIFNlcnZpY2VzLCBJ
+    bmMuMRMwEQYDVQQLDApBbWF6b24gUkRTMQswCQYDVQQIDAJXQTE0MDIGA1UEAwwr
+    QW1hem9uIFJEUyB1cy1nb3Ytd2VzdC0xIFJvb3QgQ0EgUlNBNDA5NiBHMTEQMA4G
+    A1UEBwwHU2VhdHRsZTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANwY
+    M2iZdnnlMutI9nfn2fWBICAQHWmMmpPmtSka/ziBFyaCxkHDF8RLmooW+GLe+FEF
+    9CQKSVqRa7X5AFiqRFF1KvgxWvazawyScuw88JW6Eqhaw0Rlm2p1Iow3TE8FSCDo
+    Is1vEV3Brbf26CMiXbqI+aCuTOy0fjRzjl5igViTgZxt2ZXOwyKkF+2T8LQp4b4F
+    Mh85Ctw1An1DhAemsc3SmcYnPKyFUP90DxGuTjFtfNR01GbBtVYwVvOBgIJe59Zs
+    OWcEFOO2mU53Ik6oKcLYu4+PmE5aDvQewb6bkQZchClb7Eg0BPYekWwTPsKUTS3H
+    bgdwVxgzjdAdU9fvaaoQmS9xdHWlonKq8CubJdLUduV3WVmDAg7MQgiT3p8JF9W2
+    KbQpUbYxqd7j9OIe3IS3rVPwYA8PVh1hUJ+OBLw61sbGRAuN3H+B1DlJh1smg6bR
+    g9W+oLRzfjZa32EzFmaQIxtgRfiyjxB/vqAHdl5zPou30X1CyRYquS870O02bvTN
+    zzWSOfRY4KPmS1YFVsN+m+R4+hSUOAE//bJ25ACP9oDO5w9NWkAux4e0UUAuWCra
+    jRROYN2J0KCogdru5G7lOQerD12zi3C2iibty6ou4tQX+MIKMMUVq8cfUH7oKv/R
+    8mL5PV/NUsgO248llo0lr9QBwQKdiw17wCxFR+8vAgMBAAGjQjBAMA8GA1UdEwEB
+    /wQFMAMBAf8wHQYDVR0OBBYEFPDYnx2xYIPDDAEjb6UcF29I6DgKMA4GA1UdDwEB
+    /wQEAwIBhjANBgkqhkiG9w0BAQwFAAOCAgEANTrAGs/GpXCADAwMGlrjXTdohp+p
+    CIp3gbnryVYZBXvO+f8hjJ8bHk0D/DiBrkjE8o0IpNaAadOZa+WvTNMsanPmGf1A
+    kD0vA9nm4gwEhBbzj9HRYX+dIhZhVWny9Kugm80s0h0hvbwTakUPOdMqkz6wn+xx
+    Owh7AIwaC5TTCsQyKlv5rjVblvU1XFgBf3Pf3wvMAfjDoAEPTXER/9mLVbXe+EmW
+    osP1JmgyDd+0WQFVK/LEDW81L5hsV5JvthAAFhGVtRw9ko5Ep28+EQUJE1wmLTdL
+    PyjB/KfJrTMDq94WolzFv4JpUStHbclkKlXtigjKeiYZ5Yvo+vLMSkXemccSfYn7
+    vdaUFD5vqWXvM4xhiYRq/tigw2E1bjmyd9L3XD7XalufZtMGWn7zT8HMPP+/Lch1
+    JjZ9LL2Y99VIqhoHcuSa95FtLpYDRQ28K03uwqxqFnOQLyPVmYwsaHKnmmwaZDjF
+    K1XxLVRLGRWvKEuSoWrsGcs3ehoxX4Knz/BaJzr/ioU1VnItj53tmOSJO0eMA6k+
+    egaVEb0FTa2F5xeLCKjgfDDWMz3v0TdL+kt+9z0THMlPWfOzd1C35ZzSIcTcRj22
+    SAzsL0t5ZTI4XvoPFF8dga78/KsBRolqdPjs0UzdlKhwh1ADOkTRgLOaaidMEgsT
+    JS/rbzD4FPbvc/g=
+    -----END CERTIFICATE-----
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/skip_hostname_validation?
+  value: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -89,6 +89,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+      - cf-manifests/bosh/opsfiles/rds-ca.yml
       - cf-manifests/bosh/opsfiles/content-security-policy.yml
       - cf-manifests/bosh/opsfiles/loggregator.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- The default behavior for `silk-controller` and `policy-server` components are to not require ssl database connections.  This PR switches ssl to be required and provides a 4096bit ssl certificate published by AWS for RDS.
- Manually tested in Dev.  Will do this as a controlled rollout with a subsequent PR to stage/prod.
- Part of https://github.com/cloud-gov/private/issues/1415

## security considerations
Moves the last of the connections of CF components to require ssl when connecting to the RDS back end.
