### PR TITLE
update test CDN service to use domain-with-cdn-dedicated-waf plan

### DIFF
--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -47,7 +47,7 @@ resource "cloudfoundry_route" "test_cdn_route" {
 resource "cloudfoundry_service_instance" "test_cdn_instance" {
   name         = "test-cdn-service"
   space        = data.cloudfoundry_space.hello_worlds.id
-  service_plan = data.cloudfoundry_service.external_domain.service_plans["domain-with-cdn"]
+  service_plan = data.cloudfoundry_service.external_domain.service_plans["domain-with-cdn-dedicated-waf"]
   json_params  = "{\"domains\": \"test-cdn.${local.domain_name}\"}"
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/1098

- update test CDN service to use domain-with-cdn-dedicated-waf plan as a test of updating existing `domain-with-cdn` instances on a CDN that we control for testing

## security considerations

This will add more robust security protections on our test CDN, which isn't strictly necessary, but is simply useful as a test of the upgrade path for existing CDN instances
