### PR TITLE
Add RDS CAs to staging and production

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -635,6 +635,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/smoke-tests.yml
       - cf-manifests/bosh/opsfiles/routing.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+      - cf-manifests/bosh/opsfiles/rds-ca.yml
       - cf-manifests/bosh/opsfiles/loggregator.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
       - cf-manifests/bosh/opsfiles/router-main.yml
@@ -1185,6 +1186,7 @@ jobs:
       - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
       - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
       - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+      - cf-manifests/bosh/opsfiles/rds-ca.yml
       - cf-manifests/bosh/opsfiles/loggregator.yml
       - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
       - cf-manifests/bosh/opsfiles/router-main.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- The default behavior for `silk-controller` and `policy-server` components are to not require ssl database connections.  This PR switches ssl to be required and provides a 4096bit ssl certificate published by AWS for RDS.
- Tested in Dev with https://github.com/cloud-gov/cg-deploy-cf/pull/884
- Part of https://github.com/cloud-gov/private/issues/1415

## security considerations
Moves the last of the connections of CF components to require ssl when connecting to the RDS back end.
