### PR TITLE
Create CSB app

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -182,6 +182,11 @@ jobs:
       TF_VAR_iaas_stack_name: development
       TF_VAR_tooling_stack_name: tooling
       TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
+      TF_VAR_remote_state_bucket_external: ((tf-state-bucket-external))
+      TF_VAR_external_stack_name: external-development
+      TF_VAR_csb_aws_region_govcloud: ((aws-region))
+      TF_VAR_csb_aws_region_commercial: ((csb-aws-region-commercial))
+      TF_VAR_csb_cg_smtp_aws_ses_zone: appmail.dev.us-gov-west-1.aws-us-gov.cloud.gov
   - put: slack
     params:
       text_file: terraform-state/message.txt

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,1846 +1,1844 @@
 ---
 jobs:
-- name: deploy-cf-development
-  serial_groups: [development]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: master-bosh-root-cert
-      trigger: true
-    - get: cf-deployment
-      trigger: true
-    - get: pipeline-tasks
-    - get: cf-manifests
-      resource: cf-manifests
-      trigger: true
-    - get: terraform-yaml
-      resource: terraform-yaml-development
-    - get: cf-stemcell-jammy
-      trigger: true
-    - get: uaa-customized-release
-      trigger: true
-    - get: cg-s3-secureproxy-release
-      trigger: true
-    - get: general-task
-  - task: terraform-secrets
-    image: general-task
-    file: cf-manifests/ci/terraform-secrets.yml
-  - task: router-main
-    image: general-task
-    file: cf-manifests/ci/create-router-main.yml
-  - task: router-logstash
-    image: general-task
-    file: cf-manifests/ci/create-router-logstash.yml
-  - task: diego-platform-cell
-    image: general-task
-    file: cf-manifests/ci/create-diego-platform-cell.yml
-  - task: diego-cell-iso-seg
-    image: general-task
-    file: cf-manifests/ci/create-diego-cell-iso-seg.yml
-    params:
-      ISO_SEG_NAMES: "" #((names_of_iso_segs_development))    # Value in credhub
-  - put: cf-deployment-development
-    params: &deploy-params
-      manifest: cf-deployment/cf-deployment.yml
-      releases:
-      - uaa-customized-release/*.tgz
-      - cg-s3-secureproxy-release/*.tgz
-      stemcells:
-      - cf-stemcell-jammy/*.tgz
-      ops_files:
-      - router-main/router_main.yml
-      - router-logstash/router_logstash.yml
-      - cf-deployment/operations/rename-network-and-deployment.yml
-      - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
-      - cf-deployment/operations/use-external-dbs.yml
-      - cf-deployment/operations/stop-skipping-tls-validation.yml
-      - cf-deployment/operations/set-bbs-active-key.yml
-      - cf-deployment/operations/enable-service-discovery.yml
-      - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
-      - cf-manifests/bosh/opsfiles/clients.yml
-      - cf-manifests/bosh/opsfiles/development-clients.yml
-      - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
-      - cf-manifests/bosh/opsfiles/users.yml
-      - cf-manifests/bosh/opsfiles/secureproxy.yml
-      - cf-manifests/bosh/opsfiles/apps-domain.yml
-      - cf-manifests/bosh/opsfiles/api-defaults.yml
-      - cf-manifests/bosh/opsfiles/uaa-customized.yml
-      - cf-manifests/bosh/opsfiles/uaa-branding.yml
-      - cf-manifests/bosh/opsfiles/uaa-groups.yml
-      - cf-manifests/bosh/opsfiles/uaa-login.yml
-      - cf-manifests/bosh/opsfiles/uaa-saml.yml
-      - cf-manifests/bosh/opsfiles/uaa-user.yml
-      - cf-manifests/bosh/opsfiles/uaa-cors.yml
-      - cf-manifests/bosh/opsfiles/encryption.yml
-      - cf-manifests/bosh/opsfiles/sql.yml
-      - cf-manifests/bosh/opsfiles/log-levels.yml
-      - cf-manifests/bosh/opsfiles/log-levels-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/instance-profiles.yml
-      - diego-platform-cell/diego-platform-cell.yml
-      - cf-manifests/bosh/opsfiles/platform-cells.yml
-      - diego-cell-iso-seg/diego-cell-iso-seg.yml
-      - cf-manifests/bosh/opsfiles/diego-cell-consumes-provides.yml
-      - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
-      - cf-manifests/bosh/opsfiles/scaling-development.yml
-      - cf-manifests/bosh/opsfiles/cf-networking.yml
-      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
-      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/smoke-tests.yml
-      - cf-manifests/bosh/opsfiles/routing.yml
-      - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
-      - cf-manifests/bosh/opsfiles/rds-ca.yml
-      - cf-manifests/bosh/opsfiles/content-security-policy.yml
-      - cf-manifests/bosh/opsfiles/loggregator.yml
-      - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/router-main.yml
-      - cf-manifests/bosh/opsfiles/router-main-dev.yml
-      - cf-manifests/bosh/opsfiles/router-logstash.yml
-      - cf-manifests/bosh/opsfiles/router-logstash-dev.yml
-      - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
-      - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
-      - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
-      - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/aggregate_drains.yml
-      vars_files:
-      - cf-manifests/bosh/varsfiles/development.yml
-      - terraform-secrets/terraform.yml
+  - name: deploy-cf-development
+    serial_groups: [development]
+    serial: true
+    plan:
+      - in_parallel:
+          - get: master-bosh-root-cert
+            trigger: true
+          - get: cf-deployment
+            trigger: true
+          - get: pipeline-tasks
+          - get: cf-manifests
+            resource: cf-manifests
+            trigger: true
+          - get: terraform-yaml
+            resource: terraform-yaml-development
+          - get: cf-stemcell-jammy
+            trigger: true
+          - get: uaa-customized-release
+            trigger: true
+          - get: cg-s3-secureproxy-release
+            trigger: true
+          - get: general-task
+      - task: terraform-secrets
+        image: general-task
+        file: cf-manifests/ci/terraform-secrets.yml
+      - task: router-main
+        image: general-task
+        file: cf-manifests/ci/create-router-main.yml
+      - task: router-logstash
+        image: general-task
+        file: cf-manifests/ci/create-router-logstash.yml
+      - task: diego-platform-cell
+        image: general-task
+        file: cf-manifests/ci/create-diego-platform-cell.yml
+      - task: diego-cell-iso-seg
+        image: general-task
+        file: cf-manifests/ci/create-diego-cell-iso-seg.yml
+        params:
+          ISO_SEG_NAMES: "" #((names_of_iso_segs_development))    # Value in credhub
+      - put: cf-deployment-development
+        params: &deploy-params
+          manifest: cf-deployment/cf-deployment.yml
+          releases:
+            - uaa-customized-release/*.tgz
+            - cg-s3-secureproxy-release/*.tgz
+          stemcells:
+            - cf-stemcell-jammy/*.tgz
+          ops_files:
+            - router-main/router_main.yml
+            - router-logstash/router_logstash.yml
+            - cf-deployment/operations/rename-network-and-deployment.yml
+            - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
+            - cf-deployment/operations/use-external-dbs.yml
+            - cf-deployment/operations/stop-skipping-tls-validation.yml
+            - cf-deployment/operations/set-bbs-active-key.yml
+            - cf-deployment/operations/enable-service-discovery.yml
+            - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
+            - cf-manifests/bosh/opsfiles/clients.yml
+            - cf-manifests/bosh/opsfiles/development-clients.yml
+            - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
+            - cf-manifests/bosh/opsfiles/users.yml
+            - cf-manifests/bosh/opsfiles/secureproxy.yml
+            - cf-manifests/bosh/opsfiles/apps-domain.yml
+            - cf-manifests/bosh/opsfiles/api-defaults.yml
+            - cf-manifests/bosh/opsfiles/uaa-customized.yml
+            - cf-manifests/bosh/opsfiles/uaa-branding.yml
+            - cf-manifests/bosh/opsfiles/uaa-groups.yml
+            - cf-manifests/bosh/opsfiles/uaa-login.yml
+            - cf-manifests/bosh/opsfiles/uaa-saml.yml
+            - cf-manifests/bosh/opsfiles/uaa-user.yml
+            - cf-manifests/bosh/opsfiles/uaa-cors.yml
+            - cf-manifests/bosh/opsfiles/encryption.yml
+            - cf-manifests/bosh/opsfiles/sql.yml
+            - cf-manifests/bosh/opsfiles/log-levels.yml
+            - cf-manifests/bosh/opsfiles/log-levels-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/instance-profiles.yml
+            - diego-platform-cell/diego-platform-cell.yml
+            - cf-manifests/bosh/opsfiles/platform-cells.yml
+            - diego-cell-iso-seg/diego-cell-iso-seg.yml
+            - cf-manifests/bosh/opsfiles/diego-cell-consumes-provides.yml
+            - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
+            - cf-manifests/bosh/opsfiles/scaling-development.yml
+            - cf-manifests/bosh/opsfiles/cf-networking.yml
+            - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+            - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/smoke-tests.yml
+            - cf-manifests/bosh/opsfiles/routing.yml
+            - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+            - cf-manifests/bosh/opsfiles/rds-ca.yml
+            - cf-manifests/bosh/opsfiles/content-security-policy.yml
+            - cf-manifests/bosh/opsfiles/loggregator.yml
+            - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/router-main.yml
+            - cf-manifests/bosh/opsfiles/router-main-dev.yml
+            - cf-manifests/bosh/opsfiles/router-logstash.yml
+            - cf-manifests/bosh/opsfiles/router-logstash-dev.yml
+            - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
+            - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
+            - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
+            - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/aggregate_drains.yml
+          vars_files:
+            - cf-manifests/bosh/varsfiles/development.yml
+            - terraform-secrets/terraform.yml
 
-  - task: enable-cf-features
-    image: general-task
-    file: cf-manifests/ci/enable-cf-features.yml
-    params:
-      CF_API_URL: ((cf-api-url-development))
-      CF_USERNAME: ((cf-username-development))
-      CF_PASSWORD: ((cf-password-development))
-      ENABLED_FEATURE_FLAGS: |
-        private_domain_creation
-        app_bits_upload
-        app_scaling
-        route_creation
-        service_instance_creation
-        diego_docker
-        set_roles_by_username
-        unset_roles_by_username
-        task_creation
-        env_var_visibility
-        space_scoped_private_broker_creation
-        space_developer_env_var_visibility
-        service_instance_sharing
-        resource_matching
-        route_sharing
-      DISABLED_FEATURE_FLAGS: |
-        user_org_creation
-        hide_marketplace_from_unauthenticated_users
+      - task: enable-cf-features
+        image: general-task
+        file: cf-manifests/ci/enable-cf-features.yml
+        params:
+          CF_API_URL: ((cf-api-url-development))
+          CF_USERNAME: ((cf-username-development))
+          CF_PASSWORD: ((cf-password-development))
+          ENABLED_FEATURE_FLAGS: |
+            private_domain_creation
+            app_bits_upload
+            app_scaling
+            route_creation
+            service_instance_creation
+            diego_docker
+            set_roles_by_username
+            unset_roles_by_username
+            task_creation
+            env_var_visibility
+            space_scoped_private_broker_creation
+            space_developer_env_var_visibility
+            service_instance_sharing
+            resource_matching
+            route_sharing
+          DISABLED_FEATURE_FLAGS: |
+            user_org_creation
+            hide_marketplace_from_unauthenticated_users
 
-
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed CF on development
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy CF on development
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-
-- name: terraform-plan-development
-  plan:
-  - in_parallel:
-    - get: terraform-templates
-      resource: terraform-config
-      trigger: true
-    - get: terraform-yaml
-      resource: terraform-yaml-development
-      trigger: true
-    - get: pipeline-tasks
-    - get: general-task
-  - task: terraform-plan
-    image: general-task
-    file: terraform-templates/terraform/terraform-apply.yml
-    params: &tf-development
-      TERRAFORM_ACTION: plan
-      TEMPLATE_SUBDIR: terraform/stack
-      STACK_NAME: cf-development
-      S3_TFSTATE_BUCKET: ((tf-state-bucket))
-      AWS_DEFAULT_REGION: ((aws-region))
-      CF_API_URL: ((cf-api-url-development))
-      CF_CLIENT_ID: ((cf-client-id-development))
-      CF_CLIENT_SECRET: ((cf-client-secret-development))
-      TF_VAR_remote_state_bucket: ((tf-state-bucket))
-      TF_VAR_domain_name: dev.us-gov-west-1.aws-us-gov.cloud.gov
-      TF_VAR_iaas_stack_name: development
-      TF_VAR_tooling_stack_name: tooling
-      TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
-      TF_VAR_remote_state_bucket_external: ((tf-state-bucket-external))
-      TF_VAR_external_stack_name: external-development
-      TF_VAR_csb_aws_region_govcloud: ((aws-region))
-      TF_VAR_csb_aws_region_commercial: ((csb-aws-region-commercial))
-      TF_VAR_csb_cg_smtp_aws_ses_zone: appmail.dev.us-gov-west-1.aws-us-gov.cloud.gov
-  - put: slack
-    params:
-      text_file: terraform-state/message.txt
-      text:  |
-        :terraform: $BUILD_JOB_NAME needs review
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: terraform-apply-development
-  plan:
-  - in_parallel:
-    - get: terraform-templates
-      resource: terraform-config
-      passed: [terraform-plan-development]
-      trigger: true
-    - get: pipeline-tasks
-    - get: general-task
-  - task: terraform-apply
-    image: general-task
-    file: terraform-templates/terraform/terraform-apply.yml
-    params:
-      <<: *tf-development
-      TERRAFORM_ACTION: apply
-
-- name: uaa-smoke-tests-development
-  plan:
-  - in_parallel:
-    - get: pipeline-tasks
-    - get: common
-      resource: master-bosh-root-cert
-      passed: [deploy-cf-development]
-      trigger: true
-    - get: cf-deployment-development
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-deployment
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-stemcell-jammy
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-manifests
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: uaa-customized-release
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cg-s3-secureproxy-release
-      trigger: true
-      passed: [deploy-cf-development]
-  - task: smoke-tests
-    file: pipeline-tasks/uaa-smoke-tests.yml
-    params:
-      BASE_URL: ((uaa-url-development))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: UAA Smoke Tests for CF on development FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: uaa-client-auditing-development
-  plan:
-  - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
-      passed: [deploy-cf-development]
-    - get: tests-timer
-      trigger: true
-    - get: general-task
-  - task: uaa-client-audit
-    image: general-task
-    file: cf-manifests/ci/uaa-client-audit.yml
-    params:
-      UAA_URL: ((uaa-url-development))
-      UAA_CLIENT_ID: ((uaa-audit-client-id-development))
-      UAA_CLIENT_SECRET: ((uaa-audit-client-secret-development))
-      CF_API_URL: ((cf-api-url-development))
-      GATEWAY_HOST: prometheus-staging.service.cf.internal
-      WHITELIST: ((uaa-audit-whitelist-development))
-
-- name: uaa-monitor-account-creation-development
-  plan:
-  - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
-      passed: [deploy-cf-development]
-    - get: hourly-timer
-      trigger: true
-    - get: general-task
-  - task: uaa-monitor-account-creation
-    image: general-task
-    file: cf-manifests/ci/uaa-monitor-account-creation.yml
-    params:
-      UAA_URL: ((uaa-url-development))
-      UAA_CLIENT_ID: ((uaa-audit-client-id-development))
-      UAA_CLIENT_SECRET: ((uaa-audit-client-secret-development))
-      GATEWAY_HOST: prometheus-staging.service.cf.internal
-
-- name: tic-smoke-tests-development
-  plan:
-  - in_parallel:
-    - get: master-bosh-root-cert
-      passed: [deploy-cf-development]
-      trigger: true
-    - get: cf-deployment-development
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-deployment
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-stemcell-jammy
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-manifests
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: uaa-customized-release
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cg-s3-secureproxy-release
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: general-task
-  - task: smoke-tests
-    image: general-task
-    file: cf-manifests/ci/tic-smoke-tests.yml
-    params:
-      CI: true
-      API_HOSTNAME: api.dev.us-gov-west-1.aws-us-gov.cloud.gov
-      DASHBOARD_HOSTNAME: dashboard.dev.us-gov-west-1.aws-us-gov.cloud.gov
-      BOSH_ENVIRONMENT: ((development-bosh-target))
-      BOSH_CLIENT: ((development-bosh-username))
-      BOSH_CLIENT_SECRET: ((development-bosh-password))
-      BOSH_DEPLOYMENT_NAME: cf-development
-      BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      RESTRICTED_DOMAIN: ((tic-test-restricted-domain))
-      UNRESTRICTED_DOMAIN: ((tic-test-unrestricted-domain))
-      SOURCE_ADDRESS_ALLOWED: ((tic-test-source-address-allowed))
-      SOURCE_ADDRESS_FORBIDDEN: ((tic-test-source-address-forbidden))
-      PROXY_ADDRESS_ALLOWED: ((tic-test-proxy-address-allowed))
-      PROXY_ADDRESS_FORBIDDEN: ((tic-test-proxy-address-forbidden))
-      TIC_SECRET_ALLOWED: ((tic-secret-development))
-      TIC_SECRET_FORBIDDEN: ((tic-test-tic-secret-forbidden))
-      TIC_PROTOCAL: https
-      GOROUTER_PORT: 443
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: TIC Smoke Tests for CF on development FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: smoke-tests-development
-  serial_groups: [development]
-  plan:
-  - in_parallel:
-    - get: common
-      resource: master-bosh-root-cert
-      passed:
-      - tic-smoke-tests-development
-      - uaa-smoke-tests-development
-      trigger: true
-    - get: cf-deployment-development
-      trigger: true
-      passed:
-      - tic-smoke-tests-development
-      - uaa-smoke-tests-development
-      - test-space-egress-development
-    - get: cf-deployment
-      trigger: true
-      passed:
-      - tic-smoke-tests-development
-      - uaa-smoke-tests-development
-      - test-space-egress-development
-    - get: cf-stemcell-jammy
-      trigger: true
-      passed:
-      - tic-smoke-tests-development
-      - uaa-smoke-tests-development
-      - test-space-egress-development
-    - get: cf-manifests
-      trigger: true
-      passed:
-      - tic-smoke-tests-development
-      - uaa-smoke-tests-development
-      - test-space-egress-development
-    - get: uaa-customized-release
-      trigger: true
-      passed:
-      - tic-smoke-tests-development
-      - uaa-smoke-tests-development
-    - get: cg-s3-secureproxy-release
-      trigger: true
-      passed:
-      - tic-smoke-tests-development
-      - uaa-smoke-tests-development
-  - task: run-errand
-    attempts: 3
-    params:
-      BOSH_ENVIRONMENT: ((bosh.development.environment))
-      BOSH_CLIENT: ((bosh.development.client))
-      BOSH_CLIENT_SECRET: ((bosh.development.client-secret))
-      BOSH_DEPLOYMENT: ((cf.development.name))
-      BOSH_ERRAND: ((cf.development.smoke-tests))
-      BOSH_CA_CERT: common/master-bosh.crt
-    config: &smoke-tests-errand
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          aws_access_key_id: ((ecr_aws_key))
-          aws_secret_access_key: ((ecr_aws_secret))
-          repository: general-task
-          aws_region: us-gov-west-1
-          tag: latest
-      inputs:
-        - name: common
-      run:
-        path: /bin/bash
-        args:
-        - -euxc
-        - |
-          bosh run-errand smoke-tests
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Smoke Tests for CF on development PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: Smoke Tests for CF on development FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: test-space-egress-development
-  serial_groups: [development]
-  plan:
-  - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-deployment-development
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-stemcell-jammy
-      passed: [deploy-cf-development]
-    - get: general-task
-  - task: deploy-test-env
-    image: general-task
-    file: cf-manifests/ci/test-space-egress/task-deploy-test-env.yml
-    params: &test-space-egress-development-params
-      CF_API_URL: ((cf-api-url-development))
-      CF_USERNAME: ((cf-username-development))
-      CF_PASSWORD: ((cf-password-development))
-      CF_ORG: platform-test-space-egress
-      CF_QUOTA: default
-      CF_APP_DOMAIN: dev.us-gov-west-1.aws-us-gov.cloud.gov
-    on_failure: &test-space-egress-development-clean-tasks
-      task: clean-test-env
-      image: general-task
-      file: cf-manifests/ci/test-space-egress/task-clean-test-env.yml
-      params:
-        <<: *test-space-egress-development-params
-  - task: run-tests
-    image: general-task
-    file: cf-manifests/ci/test-space-egress/task-run-tests.yml
-    params:
-      <<: *test-space-egress-development-params
-    on_failure:
-      <<: *test-space-egress-development-clean-tasks
     on_success:
-      <<: *test-space-egress-development-clean-tasks
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Tests for space egress for CF on development PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: Tests for space egress for CF on development FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: test-headers-development
-  serial_groups: [development]
-  plan:
-  - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-deployment-development
-      trigger: true
-      passed: [deploy-cf-development]
-    - get: cf-stemcell-jammy
-      passed: [deploy-cf-development]
-    - get: general-task
-  - task: deploy-test-env
-    image: general-task
-    file: cf-manifests/ci/test-headers/task-deploy-test-env.yml
-    params: &test-headers-development-params
-      CF_API_URL: ((cf-api-url-development))
-      CF_USERNAME: ((cf-username-development))
-      CF_PASSWORD: ((cf-password-development))
-      CF_ORG: platform-test-headers
-      CF_QUOTA: default
-      CF_APP_DOMAIN: dev.us-gov-west-1.aws-us-gov.cloud.gov
-    on_failure: &test-headers-development-clean-tasks
-      task: clean-test-env
-      image: general-task
-      file: cf-manifests/ci/test-headers/task-clean-test-env.yml
+      put: slack
       params:
-        <<: *test-headers-development-params
-  - task: run-tests
-    image: general-task
-    file: cf-manifests/ci/test-headers/task-run-tests.yml
-    params:
-      <<: *test-headers-development-params
+        text: |
+          :white_check_mark: Successfully deployed CF on development
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
     on_failure:
-      <<: *test-headers-development-clean-tasks
-    on_success:
-      <<: *test-headers-development-clean-tasks
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Tests for headers for CF on development PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: Tests for headers for CF on development FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: deploy-cf-staging
-  serial_groups: [staging]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: master-bosh-root-cert
-    - get: cf-deployment
-      trigger: true
-      passed: [smoke-tests-development]
-    - get: pipeline-tasks
-    - get: cf-manifests
-      trigger: true
-      passed: [smoke-tests-development]
-    - get: terraform-yaml
-      resource: terraform-yaml-staging
-    - get: cf-stemcell-jammy
-      trigger: true
-      passed: [smoke-tests-development]
-    - get: uaa-customized-release
-      trigger: true
-      passed: [smoke-tests-development]
-    - get: cg-s3-secureproxy-release
-      trigger: true
-      passed: [smoke-tests-development]
-    - get: general-task
-  - put: timestamp
-  - task: terraform-secrets
-    image: general-task
-    file: cf-manifests/ci/terraform-secrets.yml
-  - task: router-main
-    image: general-task
-    file: cf-manifests/ci/create-router-main.yml
-  - task: router-logstash
-    image: general-task
-    file: cf-manifests/ci/create-router-logstash.yml
-  - task: diego-platform-cell
-    image: general-task
-    file: cf-manifests/ci/create-diego-platform-cell.yml
-  - task: diego-cell-iso-seg
-    image: general-task
-    file: cf-manifests/ci/create-diego-cell-iso-seg.yml
-    params:
-      ISO_SEG_NAMES: "" #((names_of_iso_segs_staging))    # Value in credhub
-  - put: cf-deployment-staging
-    params:
-      <<: *deploy-params
-      ops_files:
-      - router-main/router_main.yml
-      - router-logstash/router_logstash.yml
-      - cf-deployment/operations/rename-network-and-deployment.yml
-      - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
-      - cf-deployment/operations/use-external-dbs.yml
-      - cf-deployment/operations/stop-skipping-tls-validation.yml
-      - cf-deployment/operations/set-bbs-active-key.yml
-      - cf-deployment/operations/enable-service-discovery.yml
-      - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
-      - cf-manifests/bosh/opsfiles/clients.yml
-      - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
-      - cf-manifests/bosh/opsfiles/pages-clients-staging.yml
-      - cf-manifests/bosh/opsfiles/users.yml
-      - cf-manifests/bosh/opsfiles/secureproxy.yml
-      - cf-manifests/bosh/opsfiles/apps-domain.yml
-      - cf-manifests/bosh/opsfiles/api-defaults.yml
-      - cf-manifests/bosh/opsfiles/uaa-customized.yml
-      - cf-manifests/bosh/opsfiles/uaa-branding.yml
-      - cf-manifests/bosh/opsfiles/uaa-groups.yml
-      - cf-manifests/bosh/opsfiles/uaa-login.yml
-      - cf-manifests/bosh/opsfiles/uaa-saml.yml
-      - cf-manifests/bosh/opsfiles/uaa-oauth-providers.yml
-      - cf-manifests/bosh/opsfiles/uaa-user.yml
-      - cf-manifests/bosh/opsfiles/uaa-cors.yml
-      - cf-manifests/bosh/opsfiles/encryption.yml
-      - cf-manifests/bosh/opsfiles/sql.yml
-      - cf-manifests/bosh/opsfiles/log-levels.yml
-      - cf-manifests/bosh/opsfiles/log-levels-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/instance-profiles.yml
-      - diego-platform-cell/diego-platform-cell.yml
-      - cf-manifests/bosh/opsfiles/platform-cells.yml
-      - diego-cell-iso-seg/diego-cell-iso-seg.yml
-      - cf-manifests/bosh/opsfiles/diego-cell-consumes-provides.yml
-      - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
-      - cf-manifests/bosh/opsfiles/scaling-staging.yml
-      - cf-manifests/bosh/opsfiles/cf-networking.yml
-      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
-      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/smoke-tests.yml
-      - cf-manifests/bosh/opsfiles/routing.yml
-      - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
-      - cf-manifests/bosh/opsfiles/rds-ca.yml
-      - cf-manifests/bosh/opsfiles/loggregator.yml
-      - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/router-main.yml
-      - cf-manifests/bosh/opsfiles/router-logstash.yml
-      - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
-      - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
-      - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
-      - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/aggregate_drains.yml
-      vars_files:
-      - cf-manifests/bosh/varsfiles/staging.yml
-      - terraform-secrets/terraform.yml
-
-  - task: enable-cf-features
-    image: general-task
-    file: cf-manifests/ci/enable-cf-features.yml
-    params:
-      CF_API_URL: ((cf-api-url-staging))
-      CF_USERNAME: ((cf-username-staging))
-      CF_PASSWORD: ((cf-password-staging))
-      ENABLED_FEATURE_FLAGS: |
-        private_domain_creation
-        app_bits_upload
-        app_scaling
-        route_creation
-        service_instance_creation
-        diego_docker
-        set_roles_by_username
-        unset_roles_by_username
-        task_creation
-        env_var_visibility
-        space_scoped_private_broker_creation
-        space_developer_env_var_visibility
-        service_instance_sharing
-        resource_matching
-        route_sharing
-      DISABLED_FEATURE_FLAGS: |
-        user_org_creation
-        hide_marketplace_from_unauthenticated_users
-  - task: validate-zdt
-    image: general-task
-    file: cf-manifests/ci/check-deployment-was-zdt.yml
-    params:
-      HEALTH_CHECK_ID: ((staging-route53-healthcheck-id))
-      AWS_DEFAULT_REGION: ((staging-route53-healthcheck-region))
-      AWS_ACCESS_KEY_ID: ((staging-route53-aws-access-key))
-      AWS_SECRET_ACCESS_KEY: ((staging-route53-secret-access-key))
-
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed CF on staging
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy CF on staging
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: uaa-smoke-tests-staging
-  plan:
-  - in_parallel:
-    - get: cf-deployment-staging
-      passed: [deploy-cf-staging]
-      trigger: true
-    - get: cf-manifests
-      passed: [deploy-cf-staging]
-      trigger: true
-    - get: cf-deployment
-      passed: [deploy-cf-staging]
-    - get: cf-stemcell-jammy
-      passed: [deploy-cf-staging]
-    - get: uaa-customized-release
-      passed: [deploy-cf-staging]
-    - get: cg-s3-secureproxy-release
-      passed: [deploy-cf-staging]
-    - get: terraform-config
-      trigger: true
-      passed: [terraform-apply-staging]
-    - get: pipeline-tasks
-      passed: [deploy-cf-staging]
-      trigger: true
-  - task: smoke-tests
-    file: pipeline-tasks/uaa-smoke-tests.yml
-    params:
-      BASE_URL: ((uaa-url-staging))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: UAA Smoke Tests for CF on staging FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: uaa-client-auditing-staging
-  plan:
-  - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
-      passed: [deploy-cf-staging]
-    - get: tests-timer
-      trigger: true
-    - get: general-task
-  - task: uaa-client-audit
-    image: general-task
-    file: cf-manifests/ci/uaa-client-audit.yml
-    params:
-      UAA_URL: ((uaa-url-staging))
-      UAA_CLIENT_ID: ((uaa-audit-client-id-staging))
-      UAA_CLIENT_SECRET: ((uaa-audit-client-secret-staging))
-      CF_API_URL: ((cf-api-url-staging))
-      GATEWAY_HOST: prometheus-staging.service.cf.internal
-      WHITELIST: ((uaa-audit-whitelist-staging))
-
-- name: uaa-monitor-account-creation-staging
-  plan:
-  - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
-      passed: [deploy-cf-staging]
-    - get: hourly-timer
-      trigger: true
-    - get: general-task
-  - task: uaa-monitor-account-creation
-    image: general-task
-    file: cf-manifests/ci/uaa-monitor-account-creation.yml
-    params:
-      UAA_URL: ((uaa-url-staging))
-      UAA_CLIENT_ID: ((uaa-audit-client-id-staging))
-      UAA_CLIENT_SECRET: ((uaa-audit-client-secret-staging))
-      GATEWAY_HOST: prometheus-staging.service.cf.internal
-
-- name: tic-smoke-tests-staging
-  plan:
-  - in_parallel:
-    - get: cf-deployment-staging
-      passed: [deploy-cf-staging]
-      trigger: true
-    - get: cf-manifests
-      passed: [deploy-cf-staging]
-      trigger: true
-    - get: cf-deployment
-      passed: [deploy-cf-staging]
-    - get: cf-stemcell-jammy
-      passed: [deploy-cf-staging]
-    - get: uaa-customized-release
-      passed: [deploy-cf-staging]
-    - get: cg-s3-secureproxy-release
-      passed: [deploy-cf-staging]
-    - get: terraform-config
-      passed: [terraform-apply-staging]
-      trigger: true
-    - get: master-bosh-root-cert
-    - get: general-task
-  - task: smoke-tests
-    image: general-task
-    file: cf-manifests/ci/tic-smoke-tests.yml
-    params:
-      CI: true
-      API_HOSTNAME: api.fr-stage.cloud.gov
-      DASHBOARD_HOSTNAME: dashboard.fr-stage.cloud.gov
-      BOSH_ENVIRONMENT: ((staging-bosh-target))
-      BOSH_CLIENT: ((staging-bosh-username))
-      BOSH_CLIENT_SECRET: ((staging-bosh-password))
-      BOSH_DEPLOYMENT_NAME: cf-staging
-      BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      RESTRICTED_DOMAIN: ((tic-test-restricted-domain))
-      UNRESTRICTED_DOMAIN: ((tic-test-unrestricted-domain))
-      SOURCE_ADDRESS_ALLOWED: ((tic-test-source-address-allowed))
-      SOURCE_ADDRESS_FORBIDDEN: ((tic-test-source-address-forbidden))
-      PROXY_ADDRESS_ALLOWED: ((tic-test-proxy-address-allowed))
-      PROXY_ADDRESS_FORBIDDEN: ((tic-test-proxy-address-forbidden))
-      TIC_SECRET_ALLOWED: ((tic-secret-staging))
-      TIC_SECRET_FORBIDDEN: ((tic-test-tic-secret-forbidden))
-      TIC_PROTOCAL: https
-      GOROUTER_PORT: 443
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: TIC Smoke Tests for CF on staging FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: terraform-plan-staging
-  plan:
-  - in_parallel:
-    - get: terraform-templates
-      resource: terraform-config
-      trigger: true
-      passed: [terraform-apply-development]
-    - get: terraform-yaml
-      resource: terraform-yaml-staging
-      trigger: true
-    - get: pipeline-tasks
-    - get: general-task
-  - task: terraform-plan
-    image: general-task
-    file: terraform-templates/terraform/terraform-apply.yml
-    params: &tf-staging
-      TERRAFORM_ACTION: plan
-      TEMPLATE_SUBDIR: terraform/stack
-      STACK_NAME: cf-staging
-      S3_TFSTATE_BUCKET: ((tf-state-bucket))
-      AWS_DEFAULT_REGION: ((aws-region))
-      CF_API_URL: ((cf-api-url-staging))
-      CF_CLIENT_ID: ((cf-client-id-staging))
-      CF_CLIENT_SECRET: ((cf-client-secret-staging))
-      TF_VAR_remote_state_bucket: ((tf-state-bucket))
-      TF_VAR_domain_name: fr-stage.cloud.gov
-      TF_VAR_iaas_stack_name: staging
-      TF_VAR_tooling_stack_name: tooling
-  - put: slack
-    params:
-      text_file: terraform-state/message.txt
-      text:  |
-        :terraform: $BUILD_JOB_NAME needs review
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: terraform-apply-staging
-  plan:
-  - in_parallel:
-    - get: terraform-templates
-      resource: terraform-config
-      trigger: true
-      passed: [terraform-plan-staging]
-    - get: pipeline-tasks
-    - get: general-task
-  - task: terraform-apply
-    image: general-task
-    file: terraform-templates/terraform/terraform-apply.yml
-    params:
-      <<: *tf-staging
-      TERRAFORM_ACTION: apply
-
-- name: smoke-tests-staging
-  serial_groups: [staging]
-  plan:
-  - in_parallel:
-    - get: common
-      resource: master-bosh-root-cert
-      trigger: true
-      passed: [deploy-cf-staging]
-    - get: cf-deployment-staging
-      passed: [deploy-cf-staging]
-      trigger: true
-    - get: cf-manifests
-      passed: [deploy-cf-staging]
-      trigger: true
-    - get: cf-deployment
-      trigger: true
-      passed: [deploy-cf-staging]
-    - get: cf-stemcell-jammy
-      trigger: true
-      passed: [deploy-cf-staging]
-    - get: uaa-customized-release
-      trigger: true
-      passed: [deploy-cf-staging]
-    - get: cg-s3-secureproxy-release
-      passed: [deploy-cf-staging]
-    - get: tests-timer
-      trigger: true
-    - get: terraform-config
-      passed: [terraform-apply-staging]
-      trigger: true
-  - task: run-errand
-    attempts: 3
-    params:
-      BOSH_ENVIRONMENT: ((bosh.staging.environment))
-      BOSH_CLIENT: ((bosh.staging.client))
-      BOSH_CLIENT_SECRET: ((bosh.staging.client-secret))
-      BOSH_DEPLOYMENT: ((cf.staging.name))
-      BOSH_ERRAND: ((cf.staging.smoke-tests))
-      BOSH_CA_CERT: common/master-bosh.crt
-    config: *smoke-tests-errand
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Smoke Tests for CF on staging PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: Smoke Tests for CF on staging FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: acceptance-tests-staging
-  serial_groups: [staging]
-  plan:
-  - in_parallel:
-    - get: cf-deployment-concourse-tasks
-    - get: cf-acceptance-tests
-    - get: cf-deployment-staging
-      passed:
-      - tic-smoke-tests-staging
-      - uaa-smoke-tests-staging
-      - test-space-egress-staging
-      - smoke-tests-staging
-      trigger: true
-    # Get resources from upstream jobs for use in production deploy
-    - get: cf-manifests
-      passed:
-      - tic-smoke-tests-staging
-      - uaa-smoke-tests-staging
-      - test-space-egress-staging
-      - smoke-tests-staging
-      trigger: true
-    - get: cf-deployment
-      trigger: true
-      passed:
-      - tic-smoke-tests-staging
-      - uaa-smoke-tests-staging
-      - test-space-egress-staging
-      - smoke-tests-staging
-    - get: cf-stemcell-jammy
-      trigger: true
-      passed:
-      - tic-smoke-tests-staging
-      - uaa-smoke-tests-staging
-      - test-space-egress-staging
-      - smoke-tests-staging
-    - get: uaa-customized-release
-      trigger: true
-      passed:
-      - tic-smoke-tests-staging
-      - uaa-smoke-tests-staging
-      - test-space-egress-staging
-      - smoke-tests-staging
-    - get: cg-s3-secureproxy-release
-      trigger: true
-      passed:
-      - tic-smoke-tests-staging
-      - uaa-smoke-tests-staging
-      - test-space-egress-staging
-      - smoke-tests-staging
-    - get: terraform-config
-      trigger: true
-      passed:
-      - tic-smoke-tests-staging
-      - uaa-smoke-tests-staging
-      - test-space-egress-staging
-      - smoke-tests-staging
-    - get: general-task
-  - task: test-config
-    image: general-task
-    file: cf-manifests/ci/acceptance-tests-config.yml
-    params:
-      API_URL: api.fr-stage.cloud.gov
-      APPS_DOMAIN: fr-stage.cloud.gov
-      ADMIN_USER: admin
-      EXISTING_USER: user-tester
-      ADMIN_PASSWORD: ((admin-password-staging))
-      EXISTING_USER_PASSWORD: ((existing-user-password-staging))
-  - task: run-cats
-    file: cf-deployment-concourse-tasks/run-cats/task.yml
-    params:
-      FLAKE_ATTEMPTS: 3
-      SKIP_REGEXP: routing.API|allows\spreviously-blocked\sip|Adding\sa\swildcard\sroute\sto\sa\sdomain|forwards\sapp\smessages\sto\sregistered\ssyslog\sdrains|uses\sa\sbuildpack\sfrom\sa\sgit\surl|when\sapp\shas\smultiple\sports\smapped
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Acceptance Tests for CF on staging PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: Acceptance Tests for CF on staging FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: test-space-egress-staging
-  serial_groups: [staging]
-  plan:
-  - in_parallel:
-    - get: cf-deployment-staging
-      passed: [deploy-cf-staging]
-      trigger: true
-    - get: cf-manifests
-      passed: [deploy-cf-staging]
-      trigger: true
-    - get: cf-deployment
-      passed: [deploy-cf-staging]
-    - get: cf-stemcell-jammy
-      passed: [deploy-cf-staging]
-    - get: uaa-customized-release
-      passed: [deploy-cf-staging]
-    - get: cg-s3-secureproxy-release
-      passed: [deploy-cf-staging]
-    - get: terraform-config
-      passed: [terraform-apply-staging]
-      trigger: true
-    - get: general-task
-  - task: deploy-test-env
-    image: general-task
-    file: cf-manifests/ci/test-space-egress/task-deploy-test-env.yml
-    params: &test-space-egress-staging-params
-      CF_API_URL: ((cf-api-url-staging))
-      CF_USERNAME: ((cf-username-staging))
-      CF_PASSWORD: ((cf-password-staging))
-      CF_ORG: platform-test-space-egress
-      CF_QUOTA: default
-      CF_APP_DOMAIN: fr-stage.cloud.gov
-    on_failure: &test-space-egress-staging-clean-tasks
-      task: clean-test-env
-      image: general-task
-      file: cf-manifests/ci/test-space-egress/task-clean-test-env.yml
+      put: slack
       params:
-        <<: *test-space-egress-staging-params
-  - task: run-tests
-    image: general-task
-    file: cf-manifests/ci/test-space-egress/task-run-tests.yml
-    params:
-      <<: *test-space-egress-staging-params
+        text: |
+          :x: FAILED to deploy CF on development
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: terraform-plan-development
+    plan:
+      - in_parallel:
+          - get: terraform-templates
+            resource: terraform-config
+            trigger: true
+          - get: terraform-yaml
+            resource: terraform-yaml-development
+            trigger: true
+          - get: pipeline-tasks
+          - get: general-task
+      - task: terraform-plan
+        image: general-task
+        file: terraform-templates/terraform/terraform-apply.yml
+        params: &tf-development
+          TERRAFORM_ACTION: plan
+          TEMPLATE_SUBDIR: terraform/stack
+          STACK_NAME: cf-development
+          S3_TFSTATE_BUCKET: ((tf-state-bucket))
+          AWS_DEFAULT_REGION: ((aws-region))
+          CF_API_URL: ((cf-api-url-development))
+          CF_CLIENT_ID: ((cf-client-id-development))
+          CF_CLIENT_SECRET: ((cf-client-secret-development))
+          TF_VAR_remote_state_bucket: ((tf-state-bucket))
+          TF_VAR_domain_name: dev.us-gov-west-1.aws-us-gov.cloud.gov
+          TF_VAR_iaas_stack_name: development
+          TF_VAR_tooling_stack_name: tooling
+          TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
+          TF_VAR_remote_state_bucket_external: ((tf-state-bucket-external))
+          TF_VAR_external_stack_name: external-development
+          TF_VAR_csb_aws_region_govcloud: ((aws-region))
+          TF_VAR_csb_aws_region_commercial: ((csb-aws-region-commercial))
+          TF_VAR_csb_cg_smtp_aws_ses_zone: appmail.dev.us-gov-west-1.aws-us-gov.cloud.gov
+      - put: slack
+        params:
+          text_file: terraform-state/message.txt
+          text: |
+            :terraform: $BUILD_JOB_NAME needs review
+            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          channel: "#cg-platform-news"
+          username: ((slack-username))
+          icon_url: ((slack-icon-url))
+
+  - name: terraform-apply-development
+    plan:
+      - in_parallel:
+          - get: terraform-templates
+            resource: terraform-config
+            passed: [terraform-plan-development]
+            trigger: true
+          - get: pipeline-tasks
+          - get: general-task
+      - task: terraform-apply
+        image: general-task
+        file: terraform-templates/terraform/terraform-apply.yml
+        params:
+          <<: *tf-development
+          TERRAFORM_ACTION: apply
+
+  - name: uaa-smoke-tests-development
+    plan:
+      - in_parallel:
+          - get: pipeline-tasks
+          - get: common
+            resource: master-bosh-root-cert
+            passed: [deploy-cf-development]
+            trigger: true
+          - get: cf-deployment-development
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-deployment
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-stemcell-jammy
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-manifests
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: uaa-customized-release
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cg-s3-secureproxy-release
+            trigger: true
+            passed: [deploy-cf-development]
+      - task: smoke-tests
+        file: pipeline-tasks/uaa-smoke-tests.yml
+        params:
+          BASE_URL: ((uaa-url-development))
     on_failure:
-      <<: *test-space-egress-staging-clean-tasks
-    on_success:
-      <<: *test-space-egress-staging-clean-tasks
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Tests for space egress for CF on staging PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: Tests for space egress for CF on staging FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: plan-cf-production
-  serial_groups: [production]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: master-bosh-root-cert
-    - get: pipeline-tasks
-    - get: cf-deployment
-      passed: [acceptance-tests-staging]
-      trigger: true
-    - get: cf-manifests
-      passed: [acceptance-tests-staging]
-      trigger: true
-    - get: terraform-yaml
-      resource: terraform-yaml-production
-    - get: cf-stemcell-jammy
-      passed: [acceptance-tests-staging]
-      trigger: true
-    - get: uaa-customized-release
-      passed: [acceptance-tests-staging]
-    - get: cg-s3-secureproxy-release
-      passed: [acceptance-tests-staging]
-    - get: general-task
-  - task: terraform-secrets
-    image: general-task
-    file: cf-manifests/ci/terraform-secrets.yml
-  - task: router-main
-    image: general-task
-    file: cf-manifests/ci/create-router-main.yml
-  - task: router-logstash
-    image: general-task
-    file: cf-manifests/ci/create-router-logstash.yml
-  - task: diego-platform-cell
-    image: general-task
-    file: cf-manifests/ci/create-diego-platform-cell.yml
-  - task: diego-cell-iso-seg
-    image: general-task
-    file: cf-manifests/ci/create-diego-cell-iso-seg.yml
-    params:
-      ISO_SEG_NAMES: "" #((names_of_iso_segs_production))    # Value in credhub
-  - put: cf-deployment-production
-    params: &prod-deploy-params
-      <<: *deploy-params
-      dry_run: true
-      ops_files:
-      - router-main/router_main.yml
-      - router-logstash/router_logstash.yml
-      - cf-deployment/operations/rename-network-and-deployment.yml
-      - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
-      - cf-deployment/operations/use-external-dbs.yml
-      - cf-deployment/operations/stop-skipping-tls-validation.yml
-      - cf-deployment/operations/set-bbs-active-key.yml
-      - cf-deployment/operations/enable-service-discovery.yml
-      - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
-      - cf-manifests/bosh/opsfiles/clients.yml
-      - cf-manifests/bosh/opsfiles/pages-clients-production.yml
-      - cf-manifests/bosh/opsfiles/users.yml
-      - cf-manifests/bosh/opsfiles/secureproxy.yml
-      - cf-manifests/bosh/opsfiles/apps-domain.yml
-      - cf-manifests/bosh/opsfiles/api-defaults.yml
-      - cf-manifests/bosh/opsfiles/uaa-customized.yml
-      - cf-manifests/bosh/opsfiles/uaa-branding.yml
-      - cf-manifests/bosh/opsfiles/uaa-groups.yml
-      - cf-manifests/bosh/opsfiles/uaa-login.yml
-      - cf-manifests/bosh/opsfiles/uaa-saml.yml
-      - cf-manifests/bosh/opsfiles/uaa-oauth-providers.yml
-      - cf-manifests/bosh/opsfiles/uaa-user.yml
-      - cf-manifests/bosh/opsfiles/uaa-cors.yml
-      - cf-manifests/bosh/opsfiles/encryption.yml
-      - cf-manifests/bosh/opsfiles/sql.yml
-      - cf-manifests/bosh/opsfiles/log-levels.yml
-      - cf-manifests/bosh/opsfiles/log-levels-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/instance-profiles.yml
-      - diego-platform-cell/diego-platform-cell.yml
-      - cf-manifests/bosh/opsfiles/platform-cells.yml
-      - diego-cell-iso-seg/diego-cell-iso-seg.yml
-      - cf-manifests/bosh/opsfiles/diego-cell-consumes-provides.yml
-      - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
-      - cf-manifests/bosh/opsfiles/scaling-production.yml
-      - cf-manifests/bosh/opsfiles/cf-networking.yml
-      - cf-manifests/bosh/opsfiles/routing.yml
-      - cf-manifests/bosh/opsfiles/smoke-tests.yml
-      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
-      - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
-      - cf-manifests/bosh/opsfiles/rds-ca.yml
-      - cf-manifests/bosh/opsfiles/loggregator.yml
-      - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
-      - cf-manifests/bosh/opsfiles/router-main.yml
-      - cf-manifests/bosh/opsfiles/router-logstash.yml
-      - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
-      - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
-      - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
-      vars_files:
-      - cf-manifests/bosh/varsfiles/production.yml
-      - terraform-secrets/terraform.yml
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: CF Production plan ready for review
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to plan CF Production
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: deploy-cf-production
-  serial_groups: [production]
-  serial: true
-  plan:
-  - in_parallel:
-    - get: master-bosh-root-cert
-    - get: pipeline-tasks
-    - get: cf-deployment
-      passed: [plan-cf-production]
-    - get: cf-manifests
-      passed: [plan-cf-production]
-    - get: terraform-yaml
-      resource: terraform-yaml-production
-    - get: cf-stemcell-jammy
-      passed: [plan-cf-production]
-    - get: uaa-customized-release
-      passed: [plan-cf-production]
-    - get: cg-s3-secureproxy-release
-      passed: [plan-cf-production]
-    - get: general-task
-  - task: terraform-secrets
-    image: general-task
-    file: cf-manifests/ci/terraform-secrets.yml
-  - task: router-main
-    image: general-task
-    file: cf-manifests/ci/create-router-main.yml
-  - task: router-logstash
-    image: general-task
-    file: cf-manifests/ci/create-router-logstash.yml
-  - task: diego-platform-cell
-    image: general-task
-    file: cf-manifests/ci/create-diego-platform-cell.yml
-  - task: diego-cell-iso-seg
-    image: general-task
-    file: cf-manifests/ci/create-diego-cell-iso-seg.yml
-    params:
-      ISO_SEG_NAMES: "" #((names_of_iso_segs_production))    # Value in credhub
-  - put: cf-deployment-production
-    params:
-      <<: *prod-deploy-params
-      dry_run: false
-
-  - task: enable-cf-features
-    image: general-task
-    file: cf-manifests/ci/enable-cf-features.yml
-    params:
-      CF_API_URL: ((cf-api-url-production))
-      CF_USERNAME: ((cf-username-production))
-      CF_PASSWORD: ((cf-password-production))
-      ENABLED_FEATURE_FLAGS: |
-        private_domain_creation
-        app_bits_upload
-        app_scaling
-        route_creation
-        service_instance_creation
-        diego_docker
-        set_roles_by_username
-        unset_roles_by_username
-        task_creation
-        env_var_visibility
-        space_scoped_private_broker_creation
-        space_developer_env_var_visibility
-        service_instance_sharing
-        resource_matching
-        route_sharing
-      DISABLED_FEATURE_FLAGS: |
-        user_org_creation
-        hide_marketplace_from_unauthenticated_users
-
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed CF on prod
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy CF on prod
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: uaa-smoke-tests-production
-  plan:
-  - in_parallel:
-    - get: pipeline-tasks
-      passed: [deploy-cf-production]
-    - get: cf-deployment-production
-      passed: [deploy-cf-production]
-      trigger: true
-  - task: smoke-tests
-    file: pipeline-tasks/uaa-smoke-tests.yml
-    params:
-      BASE_URL: ((uaa-url-production))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: UAA Smoke Tests for CF on production FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: uaa-client-auditing-production
-  plan:
-  - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
-      passed: [deploy-cf-production]
-    - get: tests-timer
-      trigger: true
-    - get: general-task
-  - task: uaa-client-audit
-    image: general-task
-    file: cf-manifests/ci/uaa-client-audit.yml
-    params:
-      UAA_URL: ((uaa-url-production))
-      UAA_CLIENT_ID: ((uaa-audit-client-id-production))
-      UAA_CLIENT_SECRET: ((uaa-audit-client-secret-production))
-      CF_API_URL: ((cf-api-url-production))
-      GATEWAY_HOST: prometheus-production.service.cf.internal
-      WHITELIST: ((uaa-audit-whitelist-production))
-
-- name: uaa-monitor-account-creation-production
-  plan:
-  - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
-      passed: [deploy-cf-production]
-    - get: hourly-timer
-      trigger: true
-    - get: general-task
-  - task: uaa-monitor-account-creation
-    image: general-task
-    file: cf-manifests/ci/uaa-monitor-account-creation.yml
-    params:
-      UAA_URL: ((uaa-url-production))
-      UAA_CLIENT_ID: ((uaa-audit-client-id-production))
-      UAA_CLIENT_SECRET: ((uaa-audit-client-secret-production))
-      GATEWAY_HOST: prometheus-production.service.cf.internal
-
-- name: tic-smoke-tests-production
-  plan:
-  - in_parallel:
-    - get: cf-manifests
-      passed: [deploy-cf-production]
-    - get: cf-deployment-production
-      passed: [deploy-cf-production]
-      trigger: true
-    - get: master-bosh-root-cert
-    - get: general-task
-  - task: smoke-tests
-    image: general-task
-    file: cf-manifests/ci/tic-smoke-tests.yml
-    params:
-      CI: true
-      API_HOSTNAME: api.fr.cloud.gov
-      DASHBOARD_HOSTNAME: dashboard.fr.cloud.gov
-      BOSH_ENVIRONMENT: ((production-bosh-target))
-      BOSH_CLIENT: ((production-bosh-username))
-      BOSH_CLIENT_SECRET: ((production-bosh-password))
-      BOSH_DEPLOYMENT_NAME: cf-production
-      BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
-      RESTRICTED_DOMAIN: ((tic-test-restricted-domain))
-      UNRESTRICTED_DOMAIN: ((tic-test-unrestricted-domain))
-      SOURCE_ADDRESS_ALLOWED: ((tic-test-source-address-allowed))
-      SOURCE_ADDRESS_FORBIDDEN: ((tic-test-source-address-forbidden))
-      PROXY_ADDRESS_ALLOWED: ((tic-test-proxy-address-allowed))
-      PROXY_ADDRESS_FORBIDDEN: ((tic-test-proxy-address-forbidden))
-      TIC_SECRET_ALLOWED: ((tic-secret-production))
-      TIC_SECRET_FORBIDDEN: ((tic-test-tic-secret-forbidden))
-      TIC_PROTOCAL: https
-      GOROUTER_PORT: 443
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: TIC Smoke Tests for CF on production FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: terraform-plan-production
-  plan:
-  - in_parallel:
-    - get: terraform-templates
-      resource: terraform-config
-      passed: [acceptance-tests-staging]
-      trigger: true
-    - get: terraform-yaml
-      resource: terraform-yaml-production
-      trigger: true
-    - get: pipeline-tasks
-    - get: general-task
-  - task: terraform-plan
-    image: general-task
-    file: terraform-templates/terraform/terraform-apply.yml
-    params: &tf-production
-      TERRAFORM_ACTION: plan
-      TEMPLATE_SUBDIR: terraform/stack
-      STACK_NAME: cf-production
-      S3_TFSTATE_BUCKET: ((tf-state-bucket))
-      AWS_DEFAULT_REGION: ((aws-region))
-      CF_API_URL: ((cf-api-url-production))
-      CF_CLIENT_ID: ((cf-client-id-production))
-      CF_CLIENT_SECRET: ((cf-client-secret-production))
-      TF_VAR_remote_state_bucket: ((tf-state-bucket))
-      TF_VAR_domain_name: cloud.gov
-      TF_VAR_iaas_stack_name: production
-      TF_VAR_tooling_stack_name: tooling
-  - put: slack
-    params:
-      text_file: terraform-state/message.txt
-      text:  |
-        :terraform: $BUILD_JOB_NAME needs review
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: terraform-apply-production
-  plan:
-  - in_parallel:
-    - get: terraform-templates
-      resource: terraform-config
-
-      passed: [terraform-plan-production]
-    - get: pipeline-tasks
-    - get: general-task
-  - task: terraform-apply
-    image: general-task
-    file: terraform-templates/terraform/terraform-apply.yml
-    params:
-      <<: *tf-production
-      TERRAFORM_ACTION: apply
-
-- name: smoke-tests-production
-  serial_groups: [production]
-  plan:
-  - in_parallel:
-    - get: common
-      resource: master-bosh-root-cert
-      passed: [deploy-cf-production]
-    - get: cf-deployment-production
-      trigger: true
-    - get: tests-timer
-      trigger: true
-  - task: run-errand
-    attempts: 3
-    params:
-      BOSH_ENVIRONMENT: ((bosh.production.environment))
-      BOSH_CLIENT: ((bosh.production.client))
-      BOSH_CLIENT_SECRET: ((bosh.production.client-secret))
-      BOSH_DEPLOYMENT: ((cf.production.name))
-      BOSH_ERRAND: ((cf.production.smoke-tests))
-      BOSH_CA_CERT: common/master-bosh.crt
-    config: *smoke-tests-errand
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Smoke Tests for CF on prod PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: Smoke Tests for CF on prod FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: test-space-egress-production
-  serial_groups: [production]
-  plan:
-  - in_parallel:
-    - get: cf-deployment
-    - get: cf-manifests
-      trigger: true
-      passed: [deploy-cf-production]
-    - get: general-task
-  - task: deploy-test-env
-    image: general-task
-    file: cf-manifests/ci/test-space-egress/task-deploy-test-env.yml
-    params: &test-space-egress-production-params
-      CF_API_URL: ((cf-api-url-production))
-      CF_USERNAME: ((cf-username-production))
-      CF_PASSWORD: ((cf-password-production))
-      CF_ORG: platform-test-space-egress
-      CF_QUOTA: default
-      CF_APP_DOMAIN: app.cloud.gov
-    on_failure: &test-space-egress-production-clean-tasks
-      task: clean-test-env
-      image: general-task
-      file: cf-manifests/ci/test-space-egress/task-clean-test-env.yml
+      put: slack
       params:
-        <<: *test-space-egress-production-params
-  - task: run-tests
-    image: general-task
-    file: cf-manifests/ci/test-space-egress/task-run-tests.yml
-    params:
-      <<: *test-space-egress-production-params
+        text: |
+          :x: UAA Smoke Tests for CF on development FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: uaa-client-auditing-development
+    plan:
+      - in_parallel:
+          - get: cf-deployment
+          - get: cf-manifests
+            passed: [deploy-cf-development]
+          - get: tests-timer
+            trigger: true
+          - get: general-task
+      - task: uaa-client-audit
+        image: general-task
+        file: cf-manifests/ci/uaa-client-audit.yml
+        params:
+          UAA_URL: ((uaa-url-development))
+          UAA_CLIENT_ID: ((uaa-audit-client-id-development))
+          UAA_CLIENT_SECRET: ((uaa-audit-client-secret-development))
+          CF_API_URL: ((cf-api-url-development))
+          GATEWAY_HOST: prometheus-staging.service.cf.internal
+          WHITELIST: ((uaa-audit-whitelist-development))
+
+  - name: uaa-monitor-account-creation-development
+    plan:
+      - in_parallel:
+          - get: cf-deployment
+          - get: cf-manifests
+            passed: [deploy-cf-development]
+          - get: hourly-timer
+            trigger: true
+          - get: general-task
+      - task: uaa-monitor-account-creation
+        image: general-task
+        file: cf-manifests/ci/uaa-monitor-account-creation.yml
+        params:
+          UAA_URL: ((uaa-url-development))
+          UAA_CLIENT_ID: ((uaa-audit-client-id-development))
+          UAA_CLIENT_SECRET: ((uaa-audit-client-secret-development))
+          GATEWAY_HOST: prometheus-staging.service.cf.internal
+
+  - name: tic-smoke-tests-development
+    plan:
+      - in_parallel:
+          - get: master-bosh-root-cert
+            passed: [deploy-cf-development]
+            trigger: true
+          - get: cf-deployment-development
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-deployment
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-stemcell-jammy
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-manifests
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: uaa-customized-release
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cg-s3-secureproxy-release
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: general-task
+      - task: smoke-tests
+        image: general-task
+        file: cf-manifests/ci/tic-smoke-tests.yml
+        params:
+          CI: true
+          API_HOSTNAME: api.dev.us-gov-west-1.aws-us-gov.cloud.gov
+          DASHBOARD_HOSTNAME: dashboard.dev.us-gov-west-1.aws-us-gov.cloud.gov
+          BOSH_ENVIRONMENT: ((development-bosh-target))
+          BOSH_CLIENT: ((development-bosh-username))
+          BOSH_CLIENT_SECRET: ((development-bosh-password))
+          BOSH_DEPLOYMENT_NAME: cf-development
+          BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
+          RESTRICTED_DOMAIN: ((tic-test-restricted-domain))
+          UNRESTRICTED_DOMAIN: ((tic-test-unrestricted-domain))
+          SOURCE_ADDRESS_ALLOWED: ((tic-test-source-address-allowed))
+          SOURCE_ADDRESS_FORBIDDEN: ((tic-test-source-address-forbidden))
+          PROXY_ADDRESS_ALLOWED: ((tic-test-proxy-address-allowed))
+          PROXY_ADDRESS_FORBIDDEN: ((tic-test-proxy-address-forbidden))
+          TIC_SECRET_ALLOWED: ((tic-secret-development))
+          TIC_SECRET_FORBIDDEN: ((tic-test-tic-secret-forbidden))
+          TIC_PROTOCAL: https
+          GOROUTER_PORT: 443
     on_failure:
-      <<: *test-space-egress-production-clean-tasks
+      put: slack
+      params:
+        text: |
+          :x: TIC Smoke Tests for CF on development FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: smoke-tests-development
+    serial_groups: [development]
+    plan:
+      - in_parallel:
+          - get: common
+            resource: master-bosh-root-cert
+            passed:
+              - tic-smoke-tests-development
+              - uaa-smoke-tests-development
+            trigger: true
+          - get: cf-deployment-development
+            trigger: true
+            passed:
+              - tic-smoke-tests-development
+              - uaa-smoke-tests-development
+              - test-space-egress-development
+          - get: cf-deployment
+            trigger: true
+            passed:
+              - tic-smoke-tests-development
+              - uaa-smoke-tests-development
+              - test-space-egress-development
+          - get: cf-stemcell-jammy
+            trigger: true
+            passed:
+              - tic-smoke-tests-development
+              - uaa-smoke-tests-development
+              - test-space-egress-development
+          - get: cf-manifests
+            trigger: true
+            passed:
+              - tic-smoke-tests-development
+              - uaa-smoke-tests-development
+              - test-space-egress-development
+          - get: uaa-customized-release
+            trigger: true
+            passed:
+              - tic-smoke-tests-development
+              - uaa-smoke-tests-development
+          - get: cg-s3-secureproxy-release
+            trigger: true
+            passed:
+              - tic-smoke-tests-development
+              - uaa-smoke-tests-development
+      - task: run-errand
+        attempts: 3
+        params:
+          BOSH_ENVIRONMENT: ((bosh.development.environment))
+          BOSH_CLIENT: ((bosh.development.client))
+          BOSH_CLIENT_SECRET: ((bosh.development.client-secret))
+          BOSH_DEPLOYMENT: ((cf.development.name))
+          BOSH_ERRAND: ((cf.development.smoke-tests))
+          BOSH_CA_CERT: common/master-bosh.crt
+        config: &smoke-tests-errand
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: general-task
+              aws_region: us-gov-west-1
+              tag: latest
+          inputs:
+            - name: common
+          run:
+            path: /bin/bash
+            args:
+              - -euxc
+              - |
+                bosh run-errand smoke-tests
     on_success:
-      <<: *test-space-egress-production-clean-tasks
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Tests for space egress for CF on production PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: Tests for space egress for CF on production FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Smoke Tests for CF on development PASSED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: Smoke Tests for CF on development FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: test-space-egress-development
+    serial_groups: [development]
+    plan:
+      - in_parallel:
+          - get: cf-deployment
+          - get: cf-manifests
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-deployment-development
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-stemcell-jammy
+            passed: [deploy-cf-development]
+          - get: general-task
+      - task: deploy-test-env
+        image: general-task
+        file: cf-manifests/ci/test-space-egress/task-deploy-test-env.yml
+        params: &test-space-egress-development-params
+          CF_API_URL: ((cf-api-url-development))
+          CF_USERNAME: ((cf-username-development))
+          CF_PASSWORD: ((cf-password-development))
+          CF_ORG: platform-test-space-egress
+          CF_QUOTA: default
+          CF_APP_DOMAIN: dev.us-gov-west-1.aws-us-gov.cloud.gov
+        on_failure: &test-space-egress-development-clean-tasks
+          task: clean-test-env
+          image: general-task
+          file: cf-manifests/ci/test-space-egress/task-clean-test-env.yml
+          params:
+            <<: *test-space-egress-development-params
+      - task: run-tests
+        image: general-task
+        file: cf-manifests/ci/test-space-egress/task-run-tests.yml
+        params:
+          <<: *test-space-egress-development-params
+        on_failure:
+          <<: *test-space-egress-development-clean-tasks
+        on_success:
+          <<: *test-space-egress-development-clean-tasks
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Tests for space egress for CF on development PASSED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: Tests for space egress for CF on development FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: test-headers-development
+    serial_groups: [development]
+    plan:
+      - in_parallel:
+          - get: cf-deployment
+          - get: cf-manifests
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-deployment-development
+            trigger: true
+            passed: [deploy-cf-development]
+          - get: cf-stemcell-jammy
+            passed: [deploy-cf-development]
+          - get: general-task
+      - task: deploy-test-env
+        image: general-task
+        file: cf-manifests/ci/test-headers/task-deploy-test-env.yml
+        params: &test-headers-development-params
+          CF_API_URL: ((cf-api-url-development))
+          CF_USERNAME: ((cf-username-development))
+          CF_PASSWORD: ((cf-password-development))
+          CF_ORG: platform-test-headers
+          CF_QUOTA: default
+          CF_APP_DOMAIN: dev.us-gov-west-1.aws-us-gov.cloud.gov
+        on_failure: &test-headers-development-clean-tasks
+          task: clean-test-env
+          image: general-task
+          file: cf-manifests/ci/test-headers/task-clean-test-env.yml
+          params:
+            <<: *test-headers-development-params
+      - task: run-tests
+        image: general-task
+        file: cf-manifests/ci/test-headers/task-run-tests.yml
+        params:
+          <<: *test-headers-development-params
+        on_failure:
+          <<: *test-headers-development-clean-tasks
+        on_success:
+          <<: *test-headers-development-clean-tasks
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Tests for headers for CF on development PASSED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: Tests for headers for CF on development FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: deploy-cf-staging
+    serial_groups: [staging]
+    serial: true
+    plan:
+      - in_parallel:
+          - get: master-bosh-root-cert
+          - get: cf-deployment
+            trigger: true
+            passed: [smoke-tests-development]
+          - get: pipeline-tasks
+          - get: cf-manifests
+            trigger: true
+            passed: [smoke-tests-development]
+          - get: terraform-yaml
+            resource: terraform-yaml-staging
+          - get: cf-stemcell-jammy
+            trigger: true
+            passed: [smoke-tests-development]
+          - get: uaa-customized-release
+            trigger: true
+            passed: [smoke-tests-development]
+          - get: cg-s3-secureproxy-release
+            trigger: true
+            passed: [smoke-tests-development]
+          - get: general-task
+      - put: timestamp
+      - task: terraform-secrets
+        image: general-task
+        file: cf-manifests/ci/terraform-secrets.yml
+      - task: router-main
+        image: general-task
+        file: cf-manifests/ci/create-router-main.yml
+      - task: router-logstash
+        image: general-task
+        file: cf-manifests/ci/create-router-logstash.yml
+      - task: diego-platform-cell
+        image: general-task
+        file: cf-manifests/ci/create-diego-platform-cell.yml
+      - task: diego-cell-iso-seg
+        image: general-task
+        file: cf-manifests/ci/create-diego-cell-iso-seg.yml
+        params:
+          ISO_SEG_NAMES: "" #((names_of_iso_segs_staging))    # Value in credhub
+      - put: cf-deployment-staging
+        params:
+          <<: *deploy-params
+          ops_files:
+            - router-main/router_main.yml
+            - router-logstash/router_logstash.yml
+            - cf-deployment/operations/rename-network-and-deployment.yml
+            - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
+            - cf-deployment/operations/use-external-dbs.yml
+            - cf-deployment/operations/stop-skipping-tls-validation.yml
+            - cf-deployment/operations/set-bbs-active-key.yml
+            - cf-deployment/operations/enable-service-discovery.yml
+            - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
+            - cf-manifests/bosh/opsfiles/clients.yml
+            - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
+            - cf-manifests/bosh/opsfiles/pages-clients-staging.yml
+            - cf-manifests/bosh/opsfiles/users.yml
+            - cf-manifests/bosh/opsfiles/secureproxy.yml
+            - cf-manifests/bosh/opsfiles/apps-domain.yml
+            - cf-manifests/bosh/opsfiles/api-defaults.yml
+            - cf-manifests/bosh/opsfiles/uaa-customized.yml
+            - cf-manifests/bosh/opsfiles/uaa-branding.yml
+            - cf-manifests/bosh/opsfiles/uaa-groups.yml
+            - cf-manifests/bosh/opsfiles/uaa-login.yml
+            - cf-manifests/bosh/opsfiles/uaa-saml.yml
+            - cf-manifests/bosh/opsfiles/uaa-oauth-providers.yml
+            - cf-manifests/bosh/opsfiles/uaa-user.yml
+            - cf-manifests/bosh/opsfiles/uaa-cors.yml
+            - cf-manifests/bosh/opsfiles/encryption.yml
+            - cf-manifests/bosh/opsfiles/sql.yml
+            - cf-manifests/bosh/opsfiles/log-levels.yml
+            - cf-manifests/bosh/opsfiles/log-levels-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/instance-profiles.yml
+            - diego-platform-cell/diego-platform-cell.yml
+            - cf-manifests/bosh/opsfiles/platform-cells.yml
+            - diego-cell-iso-seg/diego-cell-iso-seg.yml
+            - cf-manifests/bosh/opsfiles/diego-cell-consumes-provides.yml
+            - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
+            - cf-manifests/bosh/opsfiles/scaling-staging.yml
+            - cf-manifests/bosh/opsfiles/cf-networking.yml
+            - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+            - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/smoke-tests.yml
+            - cf-manifests/bosh/opsfiles/routing.yml
+            - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+            - cf-manifests/bosh/opsfiles/rds-ca.yml
+            - cf-manifests/bosh/opsfiles/loggregator.yml
+            - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/router-main.yml
+            - cf-manifests/bosh/opsfiles/router-logstash.yml
+            - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
+            - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
+            - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
+            - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/aggregate_drains.yml
+          vars_files:
+            - cf-manifests/bosh/varsfiles/staging.yml
+            - terraform-secrets/terraform.yml
+
+      - task: enable-cf-features
+        image: general-task
+        file: cf-manifests/ci/enable-cf-features.yml
+        params:
+          CF_API_URL: ((cf-api-url-staging))
+          CF_USERNAME: ((cf-username-staging))
+          CF_PASSWORD: ((cf-password-staging))
+          ENABLED_FEATURE_FLAGS: |
+            private_domain_creation
+            app_bits_upload
+            app_scaling
+            route_creation
+            service_instance_creation
+            diego_docker
+            set_roles_by_username
+            unset_roles_by_username
+            task_creation
+            env_var_visibility
+            space_scoped_private_broker_creation
+            space_developer_env_var_visibility
+            service_instance_sharing
+            resource_matching
+            route_sharing
+          DISABLED_FEATURE_FLAGS: |
+            user_org_creation
+            hide_marketplace_from_unauthenticated_users
+      - task: validate-zdt
+        image: general-task
+        file: cf-manifests/ci/check-deployment-was-zdt.yml
+        params:
+          HEALTH_CHECK_ID: ((staging-route53-healthcheck-id))
+          AWS_DEFAULT_REGION: ((staging-route53-healthcheck-region))
+          AWS_ACCESS_KEY_ID: ((staging-route53-aws-access-key))
+          AWS_SECRET_ACCESS_KEY: ((staging-route53-secret-access-key))
+
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Successfully deployed CF on staging
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: FAILED to deploy CF on staging
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: uaa-smoke-tests-staging
+    plan:
+      - in_parallel:
+          - get: cf-deployment-staging
+            passed: [deploy-cf-staging]
+            trigger: true
+          - get: cf-manifests
+            passed: [deploy-cf-staging]
+            trigger: true
+          - get: cf-deployment
+            passed: [deploy-cf-staging]
+          - get: cf-stemcell-jammy
+            passed: [deploy-cf-staging]
+          - get: uaa-customized-release
+            passed: [deploy-cf-staging]
+          - get: cg-s3-secureproxy-release
+            passed: [deploy-cf-staging]
+          - get: terraform-config
+            trigger: true
+            passed: [terraform-apply-staging]
+          - get: pipeline-tasks
+            passed: [deploy-cf-staging]
+            trigger: true
+      - task: smoke-tests
+        file: pipeline-tasks/uaa-smoke-tests.yml
+        params:
+          BASE_URL: ((uaa-url-staging))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: UAA Smoke Tests for CF on staging FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: uaa-client-auditing-staging
+    plan:
+      - in_parallel:
+          - get: cf-deployment
+          - get: cf-manifests
+            passed: [deploy-cf-staging]
+          - get: tests-timer
+            trigger: true
+          - get: general-task
+      - task: uaa-client-audit
+        image: general-task
+        file: cf-manifests/ci/uaa-client-audit.yml
+        params:
+          UAA_URL: ((uaa-url-staging))
+          UAA_CLIENT_ID: ((uaa-audit-client-id-staging))
+          UAA_CLIENT_SECRET: ((uaa-audit-client-secret-staging))
+          CF_API_URL: ((cf-api-url-staging))
+          GATEWAY_HOST: prometheus-staging.service.cf.internal
+          WHITELIST: ((uaa-audit-whitelist-staging))
+
+  - name: uaa-monitor-account-creation-staging
+    plan:
+      - in_parallel:
+          - get: cf-deployment
+          - get: cf-manifests
+            passed: [deploy-cf-staging]
+          - get: hourly-timer
+            trigger: true
+          - get: general-task
+      - task: uaa-monitor-account-creation
+        image: general-task
+        file: cf-manifests/ci/uaa-monitor-account-creation.yml
+        params:
+          UAA_URL: ((uaa-url-staging))
+          UAA_CLIENT_ID: ((uaa-audit-client-id-staging))
+          UAA_CLIENT_SECRET: ((uaa-audit-client-secret-staging))
+          GATEWAY_HOST: prometheus-staging.service.cf.internal
+
+  - name: tic-smoke-tests-staging
+    plan:
+      - in_parallel:
+          - get: cf-deployment-staging
+            passed: [deploy-cf-staging]
+            trigger: true
+          - get: cf-manifests
+            passed: [deploy-cf-staging]
+            trigger: true
+          - get: cf-deployment
+            passed: [deploy-cf-staging]
+          - get: cf-stemcell-jammy
+            passed: [deploy-cf-staging]
+          - get: uaa-customized-release
+            passed: [deploy-cf-staging]
+          - get: cg-s3-secureproxy-release
+            passed: [deploy-cf-staging]
+          - get: terraform-config
+            passed: [terraform-apply-staging]
+            trigger: true
+          - get: master-bosh-root-cert
+          - get: general-task
+      - task: smoke-tests
+        image: general-task
+        file: cf-manifests/ci/tic-smoke-tests.yml
+        params:
+          CI: true
+          API_HOSTNAME: api.fr-stage.cloud.gov
+          DASHBOARD_HOSTNAME: dashboard.fr-stage.cloud.gov
+          BOSH_ENVIRONMENT: ((staging-bosh-target))
+          BOSH_CLIENT: ((staging-bosh-username))
+          BOSH_CLIENT_SECRET: ((staging-bosh-password))
+          BOSH_DEPLOYMENT_NAME: cf-staging
+          BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
+          RESTRICTED_DOMAIN: ((tic-test-restricted-domain))
+          UNRESTRICTED_DOMAIN: ((tic-test-unrestricted-domain))
+          SOURCE_ADDRESS_ALLOWED: ((tic-test-source-address-allowed))
+          SOURCE_ADDRESS_FORBIDDEN: ((tic-test-source-address-forbidden))
+          PROXY_ADDRESS_ALLOWED: ((tic-test-proxy-address-allowed))
+          PROXY_ADDRESS_FORBIDDEN: ((tic-test-proxy-address-forbidden))
+          TIC_SECRET_ALLOWED: ((tic-secret-staging))
+          TIC_SECRET_FORBIDDEN: ((tic-test-tic-secret-forbidden))
+          TIC_PROTOCAL: https
+          GOROUTER_PORT: 443
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: TIC Smoke Tests for CF on staging FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: terraform-plan-staging
+    plan:
+      - in_parallel:
+          - get: terraform-templates
+            resource: terraform-config
+            trigger: true
+            passed: [terraform-apply-development]
+          - get: terraform-yaml
+            resource: terraform-yaml-staging
+            trigger: true
+          - get: pipeline-tasks
+          - get: general-task
+      - task: terraform-plan
+        image: general-task
+        file: terraform-templates/terraform/terraform-apply.yml
+        params: &tf-staging
+          TERRAFORM_ACTION: plan
+          TEMPLATE_SUBDIR: terraform/stack
+          STACK_NAME: cf-staging
+          S3_TFSTATE_BUCKET: ((tf-state-bucket))
+          AWS_DEFAULT_REGION: ((aws-region))
+          CF_API_URL: ((cf-api-url-staging))
+          CF_CLIENT_ID: ((cf-client-id-staging))
+          CF_CLIENT_SECRET: ((cf-client-secret-staging))
+          TF_VAR_remote_state_bucket: ((tf-state-bucket))
+          TF_VAR_domain_name: fr-stage.cloud.gov
+          TF_VAR_iaas_stack_name: staging
+          TF_VAR_tooling_stack_name: tooling
+      - put: slack
+        params:
+          text_file: terraform-state/message.txt
+          text: |
+            :terraform: $BUILD_JOB_NAME needs review
+            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          channel: "#cg-platform-news"
+          username: ((slack-username))
+          icon_url: ((slack-icon-url))
+
+  - name: terraform-apply-staging
+    plan:
+      - in_parallel:
+          - get: terraform-templates
+            resource: terraform-config
+            trigger: true
+            passed: [terraform-plan-staging]
+          - get: pipeline-tasks
+          - get: general-task
+      - task: terraform-apply
+        image: general-task
+        file: terraform-templates/terraform/terraform-apply.yml
+        params:
+          <<: *tf-staging
+          TERRAFORM_ACTION: apply
+
+  - name: smoke-tests-staging
+    serial_groups: [staging]
+    plan:
+      - in_parallel:
+          - get: common
+            resource: master-bosh-root-cert
+            trigger: true
+            passed: [deploy-cf-staging]
+          - get: cf-deployment-staging
+            passed: [deploy-cf-staging]
+            trigger: true
+          - get: cf-manifests
+            passed: [deploy-cf-staging]
+            trigger: true
+          - get: cf-deployment
+            trigger: true
+            passed: [deploy-cf-staging]
+          - get: cf-stemcell-jammy
+            trigger: true
+            passed: [deploy-cf-staging]
+          - get: uaa-customized-release
+            trigger: true
+            passed: [deploy-cf-staging]
+          - get: cg-s3-secureproxy-release
+            passed: [deploy-cf-staging]
+          - get: tests-timer
+            trigger: true
+          - get: terraform-config
+            passed: [terraform-apply-staging]
+            trigger: true
+      - task: run-errand
+        attempts: 3
+        params:
+          BOSH_ENVIRONMENT: ((bosh.staging.environment))
+          BOSH_CLIENT: ((bosh.staging.client))
+          BOSH_CLIENT_SECRET: ((bosh.staging.client-secret))
+          BOSH_DEPLOYMENT: ((cf.staging.name))
+          BOSH_ERRAND: ((cf.staging.smoke-tests))
+          BOSH_CA_CERT: common/master-bosh.crt
+        config: *smoke-tests-errand
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Smoke Tests for CF on staging PASSED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: Smoke Tests for CF on staging FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: acceptance-tests-staging
+    serial_groups: [staging]
+    plan:
+      - in_parallel:
+          - get: cf-deployment-concourse-tasks
+          - get: cf-acceptance-tests
+          - get: cf-deployment-staging
+            passed:
+              - tic-smoke-tests-staging
+              - uaa-smoke-tests-staging
+              - test-space-egress-staging
+              - smoke-tests-staging
+            trigger: true
+          # Get resources from upstream jobs for use in production deploy
+          - get: cf-manifests
+            passed:
+              - tic-smoke-tests-staging
+              - uaa-smoke-tests-staging
+              - test-space-egress-staging
+              - smoke-tests-staging
+            trigger: true
+          - get: cf-deployment
+            trigger: true
+            passed:
+              - tic-smoke-tests-staging
+              - uaa-smoke-tests-staging
+              - test-space-egress-staging
+              - smoke-tests-staging
+          - get: cf-stemcell-jammy
+            trigger: true
+            passed:
+              - tic-smoke-tests-staging
+              - uaa-smoke-tests-staging
+              - test-space-egress-staging
+              - smoke-tests-staging
+          - get: uaa-customized-release
+            trigger: true
+            passed:
+              - tic-smoke-tests-staging
+              - uaa-smoke-tests-staging
+              - test-space-egress-staging
+              - smoke-tests-staging
+          - get: cg-s3-secureproxy-release
+            trigger: true
+            passed:
+              - tic-smoke-tests-staging
+              - uaa-smoke-tests-staging
+              - test-space-egress-staging
+              - smoke-tests-staging
+          - get: terraform-config
+            trigger: true
+            passed:
+              - tic-smoke-tests-staging
+              - uaa-smoke-tests-staging
+              - test-space-egress-staging
+              - smoke-tests-staging
+          - get: general-task
+      - task: test-config
+        image: general-task
+        file: cf-manifests/ci/acceptance-tests-config.yml
+        params:
+          API_URL: api.fr-stage.cloud.gov
+          APPS_DOMAIN: fr-stage.cloud.gov
+          ADMIN_USER: admin
+          EXISTING_USER: user-tester
+          ADMIN_PASSWORD: ((admin-password-staging))
+          EXISTING_USER_PASSWORD: ((existing-user-password-staging))
+      - task: run-cats
+        file: cf-deployment-concourse-tasks/run-cats/task.yml
+        params:
+          FLAKE_ATTEMPTS: 3
+          SKIP_REGEXP: routing.API|allows\spreviously-blocked\sip|Adding\sa\swildcard\sroute\sto\sa\sdomain|forwards\sapp\smessages\sto\sregistered\ssyslog\sdrains|uses\sa\sbuildpack\sfrom\sa\sgit\surl|when\sapp\shas\smultiple\sports\smapped
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Acceptance Tests for CF on staging PASSED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: Acceptance Tests for CF on staging FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: test-space-egress-staging
+    serial_groups: [staging]
+    plan:
+      - in_parallel:
+          - get: cf-deployment-staging
+            passed: [deploy-cf-staging]
+            trigger: true
+          - get: cf-manifests
+            passed: [deploy-cf-staging]
+            trigger: true
+          - get: cf-deployment
+            passed: [deploy-cf-staging]
+          - get: cf-stemcell-jammy
+            passed: [deploy-cf-staging]
+          - get: uaa-customized-release
+            passed: [deploy-cf-staging]
+          - get: cg-s3-secureproxy-release
+            passed: [deploy-cf-staging]
+          - get: terraform-config
+            passed: [terraform-apply-staging]
+            trigger: true
+          - get: general-task
+      - task: deploy-test-env
+        image: general-task
+        file: cf-manifests/ci/test-space-egress/task-deploy-test-env.yml
+        params: &test-space-egress-staging-params
+          CF_API_URL: ((cf-api-url-staging))
+          CF_USERNAME: ((cf-username-staging))
+          CF_PASSWORD: ((cf-password-staging))
+          CF_ORG: platform-test-space-egress
+          CF_QUOTA: default
+          CF_APP_DOMAIN: fr-stage.cloud.gov
+        on_failure: &test-space-egress-staging-clean-tasks
+          task: clean-test-env
+          image: general-task
+          file: cf-manifests/ci/test-space-egress/task-clean-test-env.yml
+          params:
+            <<: *test-space-egress-staging-params
+      - task: run-tests
+        image: general-task
+        file: cf-manifests/ci/test-space-egress/task-run-tests.yml
+        params:
+          <<: *test-space-egress-staging-params
+        on_failure:
+          <<: *test-space-egress-staging-clean-tasks
+        on_success:
+          <<: *test-space-egress-staging-clean-tasks
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Tests for space egress for CF on staging PASSED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: Tests for space egress for CF on staging FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: plan-cf-production
+    serial_groups: [production]
+    serial: true
+    plan:
+      - in_parallel:
+          - get: master-bosh-root-cert
+          - get: pipeline-tasks
+          - get: cf-deployment
+            passed: [acceptance-tests-staging]
+            trigger: true
+          - get: cf-manifests
+            passed: [acceptance-tests-staging]
+            trigger: true
+          - get: terraform-yaml
+            resource: terraform-yaml-production
+          - get: cf-stemcell-jammy
+            passed: [acceptance-tests-staging]
+            trigger: true
+          - get: uaa-customized-release
+            passed: [acceptance-tests-staging]
+          - get: cg-s3-secureproxy-release
+            passed: [acceptance-tests-staging]
+          - get: general-task
+      - task: terraform-secrets
+        image: general-task
+        file: cf-manifests/ci/terraform-secrets.yml
+      - task: router-main
+        image: general-task
+        file: cf-manifests/ci/create-router-main.yml
+      - task: router-logstash
+        image: general-task
+        file: cf-manifests/ci/create-router-logstash.yml
+      - task: diego-platform-cell
+        image: general-task
+        file: cf-manifests/ci/create-diego-platform-cell.yml
+      - task: diego-cell-iso-seg
+        image: general-task
+        file: cf-manifests/ci/create-diego-cell-iso-seg.yml
+        params:
+          ISO_SEG_NAMES: "" #((names_of_iso_segs_production))    # Value in credhub
+      - put: cf-deployment-production
+        params: &prod-deploy-params
+          <<: *deploy-params
+          dry_run: true
+          ops_files:
+            - router-main/router_main.yml
+            - router-logstash/router_logstash.yml
+            - cf-deployment/operations/rename-network-and-deployment.yml
+            - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
+            - cf-deployment/operations/use-external-dbs.yml
+            - cf-deployment/operations/stop-skipping-tls-validation.yml
+            - cf-deployment/operations/set-bbs-active-key.yml
+            - cf-deployment/operations/enable-service-discovery.yml
+            - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
+            - cf-manifests/bosh/opsfiles/clients.yml
+            - cf-manifests/bosh/opsfiles/pages-clients-production.yml
+            - cf-manifests/bosh/opsfiles/users.yml
+            - cf-manifests/bosh/opsfiles/secureproxy.yml
+            - cf-manifests/bosh/opsfiles/apps-domain.yml
+            - cf-manifests/bosh/opsfiles/api-defaults.yml
+            - cf-manifests/bosh/opsfiles/uaa-customized.yml
+            - cf-manifests/bosh/opsfiles/uaa-branding.yml
+            - cf-manifests/bosh/opsfiles/uaa-groups.yml
+            - cf-manifests/bosh/opsfiles/uaa-login.yml
+            - cf-manifests/bosh/opsfiles/uaa-saml.yml
+            - cf-manifests/bosh/opsfiles/uaa-oauth-providers.yml
+            - cf-manifests/bosh/opsfiles/uaa-user.yml
+            - cf-manifests/bosh/opsfiles/uaa-cors.yml
+            - cf-manifests/bosh/opsfiles/encryption.yml
+            - cf-manifests/bosh/opsfiles/sql.yml
+            - cf-manifests/bosh/opsfiles/log-levels.yml
+            - cf-manifests/bosh/opsfiles/log-levels-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/instance-profiles.yml
+            - diego-platform-cell/diego-platform-cell.yml
+            - cf-manifests/bosh/opsfiles/platform-cells.yml
+            - diego-cell-iso-seg/diego-cell-iso-seg.yml
+            - cf-manifests/bosh/opsfiles/diego-cell-consumes-provides.yml
+            - cf-manifests/bosh/opsfiles/diego-cell-disk.yml
+            - cf-manifests/bosh/opsfiles/scaling-production.yml
+            - cf-manifests/bosh/opsfiles/cf-networking.yml
+            - cf-manifests/bosh/opsfiles/routing.yml
+            - cf-manifests/bosh/opsfiles/smoke-tests.yml
+            - cf-manifests/bosh/opsfiles/disable-secure-service-credentials.yml
+            - cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
+            - cf-manifests/bosh/opsfiles/rds-ca.yml
+            - cf-manifests/bosh/opsfiles/loggregator.yml
+            - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
+            - cf-manifests/bosh/opsfiles/router-main.yml
+            - cf-manifests/bosh/opsfiles/router-logstash.yml
+            - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
+            - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
+            - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
+          vars_files:
+            - cf-manifests/bosh/varsfiles/production.yml
+            - terraform-secrets/terraform.yml
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: CF Production plan ready for review
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: FAILED to plan CF Production
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: deploy-cf-production
+    serial_groups: [production]
+    serial: true
+    plan:
+      - in_parallel:
+          - get: master-bosh-root-cert
+          - get: pipeline-tasks
+          - get: cf-deployment
+            passed: [plan-cf-production]
+          - get: cf-manifests
+            passed: [plan-cf-production]
+          - get: terraform-yaml
+            resource: terraform-yaml-production
+          - get: cf-stemcell-jammy
+            passed: [plan-cf-production]
+          - get: uaa-customized-release
+            passed: [plan-cf-production]
+          - get: cg-s3-secureproxy-release
+            passed: [plan-cf-production]
+          - get: general-task
+      - task: terraform-secrets
+        image: general-task
+        file: cf-manifests/ci/terraform-secrets.yml
+      - task: router-main
+        image: general-task
+        file: cf-manifests/ci/create-router-main.yml
+      - task: router-logstash
+        image: general-task
+        file: cf-manifests/ci/create-router-logstash.yml
+      - task: diego-platform-cell
+        image: general-task
+        file: cf-manifests/ci/create-diego-platform-cell.yml
+      - task: diego-cell-iso-seg
+        image: general-task
+        file: cf-manifests/ci/create-diego-cell-iso-seg.yml
+        params:
+          ISO_SEG_NAMES: "" #((names_of_iso_segs_production))    # Value in credhub
+      - put: cf-deployment-production
+        params:
+          <<: *prod-deploy-params
+          dry_run: false
+
+      - task: enable-cf-features
+        image: general-task
+        file: cf-manifests/ci/enable-cf-features.yml
+        params:
+          CF_API_URL: ((cf-api-url-production))
+          CF_USERNAME: ((cf-username-production))
+          CF_PASSWORD: ((cf-password-production))
+          ENABLED_FEATURE_FLAGS: |
+            private_domain_creation
+            app_bits_upload
+            app_scaling
+            route_creation
+            service_instance_creation
+            diego_docker
+            set_roles_by_username
+            unset_roles_by_username
+            task_creation
+            env_var_visibility
+            space_scoped_private_broker_creation
+            space_developer_env_var_visibility
+            service_instance_sharing
+            resource_matching
+            route_sharing
+          DISABLED_FEATURE_FLAGS: |
+            user_org_creation
+            hide_marketplace_from_unauthenticated_users
+
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Successfully deployed CF on prod
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: FAILED to deploy CF on prod
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: uaa-smoke-tests-production
+    plan:
+      - in_parallel:
+          - get: pipeline-tasks
+            passed: [deploy-cf-production]
+          - get: cf-deployment-production
+            passed: [deploy-cf-production]
+            trigger: true
+      - task: smoke-tests
+        file: pipeline-tasks/uaa-smoke-tests.yml
+        params:
+          BASE_URL: ((uaa-url-production))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: UAA Smoke Tests for CF on production FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: uaa-client-auditing-production
+    plan:
+      - in_parallel:
+          - get: cf-deployment
+          - get: cf-manifests
+            passed: [deploy-cf-production]
+          - get: tests-timer
+            trigger: true
+          - get: general-task
+      - task: uaa-client-audit
+        image: general-task
+        file: cf-manifests/ci/uaa-client-audit.yml
+        params:
+          UAA_URL: ((uaa-url-production))
+          UAA_CLIENT_ID: ((uaa-audit-client-id-production))
+          UAA_CLIENT_SECRET: ((uaa-audit-client-secret-production))
+          CF_API_URL: ((cf-api-url-production))
+          GATEWAY_HOST: prometheus-production.service.cf.internal
+          WHITELIST: ((uaa-audit-whitelist-production))
+
+  - name: uaa-monitor-account-creation-production
+    plan:
+      - in_parallel:
+          - get: cf-deployment
+          - get: cf-manifests
+            passed: [deploy-cf-production]
+          - get: hourly-timer
+            trigger: true
+          - get: general-task
+      - task: uaa-monitor-account-creation
+        image: general-task
+        file: cf-manifests/ci/uaa-monitor-account-creation.yml
+        params:
+          UAA_URL: ((uaa-url-production))
+          UAA_CLIENT_ID: ((uaa-audit-client-id-production))
+          UAA_CLIENT_SECRET: ((uaa-audit-client-secret-production))
+          GATEWAY_HOST: prometheus-production.service.cf.internal
+
+  - name: tic-smoke-tests-production
+    plan:
+      - in_parallel:
+          - get: cf-manifests
+            passed: [deploy-cf-production]
+          - get: cf-deployment-production
+            passed: [deploy-cf-production]
+            trigger: true
+          - get: master-bosh-root-cert
+          - get: general-task
+      - task: smoke-tests
+        image: general-task
+        file: cf-manifests/ci/tic-smoke-tests.yml
+        params:
+          CI: true
+          API_HOSTNAME: api.fr.cloud.gov
+          DASHBOARD_HOSTNAME: dashboard.fr.cloud.gov
+          BOSH_ENVIRONMENT: ((production-bosh-target))
+          BOSH_CLIENT: ((production-bosh-username))
+          BOSH_CLIENT_SECRET: ((production-bosh-password))
+          BOSH_DEPLOYMENT_NAME: cf-production
+          BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
+          RESTRICTED_DOMAIN: ((tic-test-restricted-domain))
+          UNRESTRICTED_DOMAIN: ((tic-test-unrestricted-domain))
+          SOURCE_ADDRESS_ALLOWED: ((tic-test-source-address-allowed))
+          SOURCE_ADDRESS_FORBIDDEN: ((tic-test-source-address-forbidden))
+          PROXY_ADDRESS_ALLOWED: ((tic-test-proxy-address-allowed))
+          PROXY_ADDRESS_FORBIDDEN: ((tic-test-proxy-address-forbidden))
+          TIC_SECRET_ALLOWED: ((tic-secret-production))
+          TIC_SECRET_FORBIDDEN: ((tic-test-tic-secret-forbidden))
+          TIC_PROTOCAL: https
+          GOROUTER_PORT: 443
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: TIC Smoke Tests for CF on production FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: terraform-plan-production
+    plan:
+      - in_parallel:
+          - get: terraform-templates
+            resource: terraform-config
+            passed: [acceptance-tests-staging]
+            trigger: true
+          - get: terraform-yaml
+            resource: terraform-yaml-production
+            trigger: true
+          - get: pipeline-tasks
+          - get: general-task
+      - task: terraform-plan
+        image: general-task
+        file: terraform-templates/terraform/terraform-apply.yml
+        params: &tf-production
+          TERRAFORM_ACTION: plan
+          TEMPLATE_SUBDIR: terraform/stack
+          STACK_NAME: cf-production
+          S3_TFSTATE_BUCKET: ((tf-state-bucket))
+          AWS_DEFAULT_REGION: ((aws-region))
+          CF_API_URL: ((cf-api-url-production))
+          CF_CLIENT_ID: ((cf-client-id-production))
+          CF_CLIENT_SECRET: ((cf-client-secret-production))
+          TF_VAR_remote_state_bucket: ((tf-state-bucket))
+          TF_VAR_domain_name: cloud.gov
+          TF_VAR_iaas_stack_name: production
+          TF_VAR_tooling_stack_name: tooling
+      - put: slack
+        params:
+          text_file: terraform-state/message.txt
+          text: |
+            :terraform: $BUILD_JOB_NAME needs review
+            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          channel: "#cg-platform"
+          username: ((slack-username))
+          icon_url: ((slack-icon-url))
+
+  - name: terraform-apply-production
+    plan:
+      - in_parallel:
+          - get: terraform-templates
+            resource: terraform-config
+
+            passed: [terraform-plan-production]
+          - get: pipeline-tasks
+          - get: general-task
+      - task: terraform-apply
+        image: general-task
+        file: terraform-templates/terraform/terraform-apply.yml
+        params:
+          <<: *tf-production
+          TERRAFORM_ACTION: apply
+
+  - name: smoke-tests-production
+    serial_groups: [production]
+    plan:
+      - in_parallel:
+          - get: common
+            resource: master-bosh-root-cert
+            passed: [deploy-cf-production]
+          - get: cf-deployment-production
+            trigger: true
+          - get: tests-timer
+            trigger: true
+      - task: run-errand
+        attempts: 3
+        params:
+          BOSH_ENVIRONMENT: ((bosh.production.environment))
+          BOSH_CLIENT: ((bosh.production.client))
+          BOSH_CLIENT_SECRET: ((bosh.production.client-secret))
+          BOSH_DEPLOYMENT: ((cf.production.name))
+          BOSH_ERRAND: ((cf.production.smoke-tests))
+          BOSH_CA_CERT: common/master-bosh.crt
+        config: *smoke-tests-errand
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Smoke Tests for CF on prod PASSED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: Smoke Tests for CF on prod FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  - name: test-space-egress-production
+    serial_groups: [production]
+    plan:
+      - in_parallel:
+          - get: cf-deployment
+          - get: cf-manifests
+            trigger: true
+            passed: [deploy-cf-production]
+          - get: general-task
+      - task: deploy-test-env
+        image: general-task
+        file: cf-manifests/ci/test-space-egress/task-deploy-test-env.yml
+        params: &test-space-egress-production-params
+          CF_API_URL: ((cf-api-url-production))
+          CF_USERNAME: ((cf-username-production))
+          CF_PASSWORD: ((cf-password-production))
+          CF_ORG: platform-test-space-egress
+          CF_QUOTA: default
+          CF_APP_DOMAIN: app.cloud.gov
+        on_failure: &test-space-egress-production-clean-tasks
+          task: clean-test-env
+          image: general-task
+          file: cf-manifests/ci/test-space-egress/task-clean-test-env.yml
+          params:
+            <<: *test-space-egress-production-params
+      - task: run-tests
+        image: general-task
+        file: cf-manifests/ci/test-space-egress/task-run-tests.yml
+        params:
+          <<: *test-space-egress-production-params
+        on_failure:
+          <<: *test-space-egress-production-clean-tasks
+        on_success:
+          <<: *test-space-egress-production-clean-tasks
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: Tests for space egress for CF on production PASSED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: Tests for space egress for CF on production FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
 
 resources:
-- name: master-bosh-root-cert
-  type: s3-iam
-  source:
-    bucket: ((cf-private-bucket))
-    region_name: ((aws-region))
-    versioned_file: master-bosh.crt
+  - name: master-bosh-root-cert
+    type: s3-iam
+    source:
+      bucket: ((cf-private-bucket))
+      region_name: ((aws-region))
+      versioned_file: master-bosh.crt
 
-- name: cf-deployment
-  type: git
-  source:
-    uri: https://github.com/cloudfoundry/cf-deployment
-    branch: main
-    tag_filter: "v*"
+  - name: cf-deployment
+    type: git
+    source:
+      uri: https://github.com/cloudfoundry/cf-deployment
+      branch: main
+      tag_filter: "v*"
 
-- name: cf-acceptance-tests
-  type: git
-  source:
-    branch: main
-    uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
+  - name: cf-acceptance-tests
+    type: git
+    source:
+      branch: main
+      uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
 
-- name: cf-deployment-concourse-tasks
-  type: git
-  source:
-    branch: main
-    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
+  - name: cf-deployment-concourse-tasks
+    type: git
+    source:
+      branch: main
+      uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
 
-- name: pipeline-tasks
-  type: git
-  source:
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-    uri: ((pipeline-tasks-git-url))
-    branch: ((pipeline-tasks-git-branch))
+  - name: pipeline-tasks
+    type: git
+    source:
+      commit_verification_keys: ((cloud-gov-pgp-keys))
+      uri: ((pipeline-tasks-git-url))
+      branch: ((pipeline-tasks-git-branch))
 
-- name: slack
-  type: slack-notification
-  source:
-    url: ((slack-webhook-url))
+  - name: slack
+    type: slack-notification
+    source:
+      url: ((slack-webhook-url))
 
-- name: cf-manifests
-  type: git
-  source:
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-    uri: ((cf-manifests-git-url))
-    branch: main
-    paths:
-    - ci/*
-    - bosh/*
+  - name: cf-manifests
+    type: git
+    source:
+      commit_verification_keys: ((cloud-gov-pgp-keys))
+      uri: ((cf-manifests-git-url))
+      branch: main
+      paths:
+        - ci/*
+        - bosh/*
 
-- name: terraform-config
-  type: git
-  source:
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-    uri: ((cf-manifests-git-url))
-    branch: main
-    paths:
-    - terraform/*
+  - name: terraform-config
+    type: git
+    source:
+      commit_verification_keys: ((cloud-gov-pgp-keys))
+      uri: ((cf-manifests-git-url))
+      branch: main
+      paths:
+        - terraform/*
 
-- name: cf-stemcell-jammy
-  type: bosh-io-stemcell
-  source:
-    name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
+  - name: cf-stemcell-jammy
+    type: bosh-io-stemcell
+    source:
+      name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
 
-- name: terraform-yaml-development
-  type: s3-iam
-  source:
-    bucket: ((tf-state-bucket))
-    versioned_file: ((tf-state-file-development))
-    region_name: ((aws-region))
+  - name: terraform-yaml-development
+    type: s3-iam
+    source:
+      bucket: ((tf-state-bucket))
+      versioned_file: ((tf-state-file-development))
+      region_name: ((aws-region))
 
-- name: terraform-yaml-staging
-  type: s3-iam
-  source:
-    bucket: ((tf-state-bucket))
-    versioned_file: ((tf-state-file-staging))
-    region_name: ((aws-region))
+  - name: terraform-yaml-staging
+    type: s3-iam
+    source:
+      bucket: ((tf-state-bucket))
+      versioned_file: ((tf-state-file-staging))
+      region_name: ((aws-region))
 
-- name: terraform-yaml-production
-  type: s3-iam
-  source:
-    bucket: ((tf-state-bucket))
-    versioned_file: ((tf-state-file-production))
-    region_name: ((aws-region))
+  - name: terraform-yaml-production
+    type: s3-iam
+    source:
+      bucket: ((tf-state-bucket))
+      versioned_file: ((tf-state-file-production))
+      region_name: ((aws-region))
 
-- name: cf-deployment-development
-  type: bosh-deployment
-  source:
-    target: ((bosh.development.environment))
-    client: ((bosh.development.client))
-    client_secret: ((bosh.development.client-secret))
-    ca_cert: ((bosh-ca-cert))
-    deployment: ((cf.development.name))
+  - name: cf-deployment-development
+    type: bosh-deployment
+    source:
+      target: ((bosh.development.environment))
+      client: ((bosh.development.client))
+      client_secret: ((bosh.development.client-secret))
+      ca_cert: ((bosh-ca-cert))
+      deployment: ((cf.development.name))
 
-- name: cf-deployment-staging
-  type: bosh-deployment
-  source:
-    target: ((bosh.staging.environment))
-    client: ((bosh.staging.client))
-    client_secret: ((bosh.staging.client-secret))
-    ca_cert: ((bosh-ca-cert))
-    deployment: ((cf.staging.name))
+  - name: cf-deployment-staging
+    type: bosh-deployment
+    source:
+      target: ((bosh.staging.environment))
+      client: ((bosh.staging.client))
+      client_secret: ((bosh.staging.client-secret))
+      ca_cert: ((bosh-ca-cert))
+      deployment: ((cf.staging.name))
 
-- name: cf-deployment-production
-  type: bosh-deployment
-  source:
-    target: ((production-bosh-target))
-    client: ((production-bosh-client))
-    client_secret: ((production-bosh-client-secret))
-    ca_cert: ((bosh-ca-cert))
-    deployment: cf-production
+  - name: cf-deployment-production
+    type: bosh-deployment
+    source:
+      target: ((production-bosh-target))
+      client: ((production-bosh-client))
+      client_secret: ((production-bosh-client-secret))
+      ca_cert: ((bosh-ca-cert))
+      deployment: cf-production
 
-- name: uaa-customized-release
-  type: s3-iam
-  source:
-    bucket: ((s3-bosh-releases-bucket))
-    private: true
-    regexp: uaa-customized-(.*).tgz
-    region_name: ((aws-region))
+  - name: uaa-customized-release
+    type: s3-iam
+    source:
+      bucket: ((s3-bosh-releases-bucket))
+      private: true
+      regexp: uaa-customized-(.*).tgz
+      region_name: ((aws-region))
 
-- name: cg-s3-secureproxy-release
-  type: s3-iam
-  source:
-    bucket: ((s3-bosh-releases-bucket))
-    private: true
-    regexp: secureproxy-(.*).tgz
-    region_name: ((aws-region))
+  - name: cg-s3-secureproxy-release
+    type: s3-iam
+    source:
+      bucket: ((s3-bosh-releases-bucket))
+      private: true
+      regexp: secureproxy-(.*).tgz
+      region_name: ((aws-region))
 
-- name: tests-timer
-  type: time
-  source:
-    interval: 10m
+  - name: tests-timer
+    type: time
+    source:
+      interval: 10m
 
-- name: hourly-timer
-  type: time
-  source:
-    interval: 1h
+  - name: hourly-timer
+    type: time
+    source:
+      interval: 1h
 
-- name: timestamp
-  type: time
+  - name: timestamp
+    type: time
 
-- name: general-task
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: general-task
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: general-task
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: general-task
+      aws_region: us-gov-west-1
+      tag: latest
 
 resource_types:
-- name: registry-image
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: registry-image-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: registry-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: slack-notification
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: slack-notification-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: slack-notification
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: slack-notification-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: bosh-deployment
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: bosh-deployment-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: bosh-deployment
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: bosh-deployment-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: s3-iam
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: s3-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: s3-iam
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: s3-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: git
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: git-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: git
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: time
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: time-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: time
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: time-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: bosh-io-stemcell
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: bosh-io-stemcell-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: bosh-io-stemcell
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: bosh-io-stemcell-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
 groups:
-- name: all
-  jobs:
-  - deploy-cf-development
-  - terraform-plan-development
-  - terraform-apply-development
-  - uaa-smoke-tests-development
-  - uaa-client-auditing-development
-  - uaa-monitor-account-creation-development
-  - tic-smoke-tests-development
-  - smoke-tests-development
-  - test-space-egress-development
-  - deploy-cf-staging
-  - terraform-plan-staging
-  - terraform-apply-staging
-  - uaa-smoke-tests-staging
-  - uaa-client-auditing-staging
-  - uaa-monitor-account-creation-staging
-  - tic-smoke-tests-staging
-  - smoke-tests-staging
-  - acceptance-tests-staging
-  - test-space-egress-staging
-  - deploy-cf-production
-  - plan-cf-production
-  - terraform-plan-production
-  - terraform-apply-production
-  - smoke-tests-production
-  - uaa-smoke-tests-production
-  - uaa-client-auditing-production
-  - uaa-monitor-account-creation-production
-  - tic-smoke-tests-production
-  - test-space-egress-production
-- name: development
-  jobs:
-  - deploy-cf-development
-  - terraform-plan-development
-  - terraform-apply-development
-  - uaa-smoke-tests-development
-  - uaa-client-auditing-development
-  - uaa-monitor-account-creation-development
-  - tic-smoke-tests-development
-  - smoke-tests-development
-  - test-space-egress-development
-  - test-headers-development
-- name: staging
-  jobs:
-  - deploy-cf-staging
-  - terraform-plan-staging
-  - terraform-apply-staging
-  - uaa-smoke-tests-staging
-  - uaa-client-auditing-staging
-  - uaa-monitor-account-creation-staging
-  - tic-smoke-tests-staging
-  - smoke-tests-staging
-  - acceptance-tests-staging
-  - test-space-egress-staging
-- name: production
-  jobs:
-  - plan-cf-production
-  - deploy-cf-production
-  - terraform-plan-production
-  - terraform-apply-production
-  - smoke-tests-production
-  - uaa-smoke-tests-production
-  - uaa-client-auditing-production
-  - uaa-monitor-account-creation-production
-  - tic-smoke-tests-production
-  - test-space-egress-production
+  - name: all
+    jobs:
+      - deploy-cf-development
+      - terraform-plan-development
+      - terraform-apply-development
+      - uaa-smoke-tests-development
+      - uaa-client-auditing-development
+      - uaa-monitor-account-creation-development
+      - tic-smoke-tests-development
+      - smoke-tests-development
+      - test-space-egress-development
+      - deploy-cf-staging
+      - terraform-plan-staging
+      - terraform-apply-staging
+      - uaa-smoke-tests-staging
+      - uaa-client-auditing-staging
+      - uaa-monitor-account-creation-staging
+      - tic-smoke-tests-staging
+      - smoke-tests-staging
+      - acceptance-tests-staging
+      - test-space-egress-staging
+      - deploy-cf-production
+      - plan-cf-production
+      - terraform-plan-production
+      - terraform-apply-production
+      - smoke-tests-production
+      - uaa-smoke-tests-production
+      - uaa-client-auditing-production
+      - uaa-monitor-account-creation-production
+      - tic-smoke-tests-production
+      - test-space-egress-production
+  - name: development
+    jobs:
+      - deploy-cf-development
+      - terraform-plan-development
+      - terraform-apply-development
+      - uaa-smoke-tests-development
+      - uaa-client-auditing-development
+      - uaa-monitor-account-creation-development
+      - tic-smoke-tests-development
+      - smoke-tests-development
+      - test-space-egress-development
+      - test-headers-development
+  - name: staging
+    jobs:
+      - deploy-cf-staging
+      - terraform-plan-staging
+      - terraform-apply-staging
+      - uaa-smoke-tests-staging
+      - uaa-client-auditing-staging
+      - uaa-monitor-account-creation-staging
+      - tic-smoke-tests-staging
+      - smoke-tests-staging
+      - acceptance-tests-staging
+      - test-space-egress-staging
+  - name: production
+    jobs:
+      - plan-cf-production
+      - deploy-cf-production
+      - terraform-plan-production
+      - terraform-apply-production
+      - smoke-tests-production
+      - uaa-smoke-tests-production
+      - uaa-client-auditing-production
+      - uaa-monitor-account-creation-production
+      - tic-smoke-tests-production
+      - test-space-egress-production

--- a/terraform/modules/csb/main.tf
+++ b/terraform/modules/csb/main.tf
@@ -1,0 +1,76 @@
+resource "cloudfoundry_user_provided_service" "db" {
+  name  = "csb-db"
+  space = "cloud-gov/services"
+  credentials = {
+    "db_name"  = var.rds_name
+    "host"     = var.rds_host
+    "name"     = var.rds_name
+    "password" = var.rds_password
+    "port"     = var.rds_port
+    "uri"      = var.rds_url
+    "username" = var.rds_username
+  }
+}
+
+resource "random_password" "csb_app_password" {
+  length      = 32
+  special     = false
+  min_special = 0
+  min_upper   = 5
+  min_numeric = 5
+  min_lower   = 5
+}
+
+resource "cloudfoundry_app" "csb" {
+  name  = "csb"
+  space = "cloud-gov/services"
+
+  docker_image = "135676904304.dkr.ecr.us-gov-west-1.amazonaws.com/csb:latest"
+  docker_credentials = {
+    "username" = var.ecr_access_key_id
+    "password" = var.ecr_secret_access_key
+  }
+
+  command    = "/app/csb serve"
+  instances  = var.instances
+  memory     = 1
+  disk_quota = 5
+  strategy   = "blue-green"
+
+  service_binding {
+    service_instance = cloudfoundry_user_provided_service.db.id
+  }
+
+  environment = {
+    # General broker configuration
+    SECURITY_USER_NAME         = "broker"
+    SECURITY_USER_PASSWORD     = random_password.csb_app_password
+    TERRAFORM_UPGRADES_ENABLED = true
+    BROKERPAK_UPDATES_ENABLED  = true
+
+    # Access keys for managing resources provisioned by brokerpaks
+    AWS_ACCESS_KEY_ID_GOVCLOUD       = var.aws_access_key_id_govcloud
+    AWS_SECRET_ACCESS_KEY_GOVCLOUD   = var.aws_secret_access_key_govcloud
+    AWS_REGION_GOVCLOUD              = var.aws_region_govcloud
+    AWS_ACCESS_KEY_ID_COMMERCIAL     = var.aws_access_key_id_commercial
+    AWS_SECRET_ACCESS_KEY_COMMERCIAL = var.aws_secret_access_key_commercial
+    AWS_REGION_COMMERCIAL            = var.aws_region_commercial
+
+    # Other values that are used by convention by all brokerpaks
+    CLOUD_GOV_ENVIRONMENT = var.stack_description
+
+    # Brokerpak-specific variables
+    CG_SMTP_AWS_ZONE = var.cg_smtp_aws_ses_zone
+  }
+
+  routes {
+    route = "csb"
+  }
+}
+
+resource "cloudfoundry_service_broker" "csb" {
+  name     = "csb"
+  password = random_password.csb_app_password
+  url      = cloudfoundry_app.csb.routes
+  username = "broker"
+}

--- a/terraform/modules/csb/variables.tf
+++ b/terraform/modules/csb/variables.tf
@@ -1,0 +1,82 @@
+# Database credentials
+
+variable "rds_host" {
+  type        = string
+  description = "Hostname of the RDS instance for the Cloud Service Broker."
+}
+
+variable "rds_port" {
+  type        = string
+  description = "Port of the RDS instance for the Cloud Service Broker."
+}
+
+variable "rds_url" {
+  type        = string
+  description = "Full URL of the RDS instance for the Cloud Service Broker."
+}
+
+variable "rds_name" {
+  type        = string
+  description = "Database name within the RDS instance for the Cloud Service Broker."
+}
+
+variable "rds_username" {
+  type        = string
+  description = "Database username of the RDS instance for the Cloud Service Broker."
+}
+
+variable "rds_password" {
+  type        = string
+  sensitive   = true
+  description = "Database password of the RDS instance for the Cloud Service Broker."
+}
+
+# Application variables
+
+variable "ecr_access_key_id" {
+  description = "For pulling the CSB image from ECR."
+  type        = string
+}
+
+variable "ecr_secret_access_key" {
+  description = "For pulling the CSB image from ECR."
+  sensitive   = true
+  type        = string
+}
+
+variable "instances" {
+  description = "Number of instances of the CSB app to run."
+  type        = number
+}
+
+variable "cg_smtp_aws_ses_zone" {
+  type        = string
+  description = "When the user does not provide a domain, a subdomain will be created for them under this DNS zone."
+}
+
+// Broker credentials
+variable "aws_access_key_id_govcloud" {
+  type = string
+}
+
+variable "aws_secret_access_key_govcloud" {
+  type      = string
+  sensitive = true
+}
+
+variable "aws_region_govcloud" {
+  type = string
+}
+
+variable "aws_access_key_id_commercial" {
+  type = string
+}
+
+variable "aws_secret_access_key_commercial" {
+  type      = string
+  sensitive = true
+}
+
+variable "aws_region_commercial" {
+  type = string
+}

--- a/terraform/modules/csb/versions.tf
+++ b/terraform/modules/csb/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "< 2.0.0"
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "< 1.0"
+    }
+  }
+}

--- a/terraform/stack/apps.tf
+++ b/terraform/stack/apps.tf
@@ -8,3 +8,27 @@ module "test_cdn" {
     cloudfoundry = cloudfoundry
   }
 }
+
+module "csb" {
+  source = "../modules/csb"
+
+  count = var.iaas_stack_name == "development" ? 1 : 0
+
+  rds_host     = data.terraform_remote_state.iaas.outputs.csb.rds.host
+  rds_port     = data.terraform_remote_state.iaas.outputs.csb.rds.port
+  rds_url      = data.terraform_remote_state.iaas.outputs.csb.rds.url
+  rds_name     = data.terraform_remote_state.iaas.outputs.csb.rds.name
+  rds_username = data.terraform_remote_state.iaas.outputs.csb.rds.username
+  rds_password = data.terraform_remote_state.iaas.outputs.csb.rds.password
+
+  ecr_access_key_id                = data.terraform_remote_state.iaas.outputs.csb.ecr_user.access_key_id_curr
+  ecr_secret_access_key            = data.terraform_remote_state.iaas.outputs.csb.ecr_user.secret_access_key_curr
+  instances                        = 1
+  cg_smtp_aws_ses_zone             = var.csb_cg_smtp_aws_ses_zone
+  aws_access_key_id_govcloud       = data.terraform_remote_state.iaas.outputs.csb.broker_user.access_key_id_curr
+  aws_secret_access_key_govcloud   = data.terraform_remote_state.iaas.outputs.csb.broker_user.secret_access_key_curr
+  aws_region_govcloud              = var.csb_aws_region_govcloud
+  aws_access_key_id_commercial     = data.terraform_remote_state.external.outputs.csb.broker_user.access_key_id_curr
+  aws_secret_access_key_commercial = data.terraform_remote_state.external.outputs.csb.broker_user.secret_access_key_curr
+  aws_region_commercial            = var.csb_aws_region_commercial
+}

--- a/terraform/stack/data.tf
+++ b/terraform/stack/data.tf
@@ -13,3 +13,11 @@ data "terraform_remote_state" "tooling" {
     key    = "${var.tooling_stack_name}/terraform.tfstate"
   }
 }
+
+data "terraform_remote_state" "external" {
+  backend = "s3"
+  config = {
+    bucket = var.remote_state_bucket
+    key    = "${var.external_stack_name}/terraform.tfstate"
+  }
+}

--- a/terraform/stack/variables.tf
+++ b/terraform/stack/variables.tf
@@ -7,5 +7,25 @@ variable "tooling_stack_name" {
 variable "iaas_stack_name" {
 }
 
+variable "remote_state_bucket_external" {
+  type = string
+}
+
+variable "external_stack_name" {
+  type = string
+}
+
 variable "domain_name" {
+}
+
+variable "csb_aws_region_govcloud" {
+  type = string
+}
+
+variable "csb_aws_region_commercial" {
+  type = string
+}
+
+variable "csb_cg_smtp_aws_ses_zone" {
+  type = string
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use terraform to create the Cloud Service Broker application in development only, to start
- Related to https://github.com/cloud-gov/product/issues/2989
- Related to https://github.com/cloud-gov/cg-provision/pull/1766

## security considerations

Uses standard Terraform security practices.
