### PR TITLE
Add credentials that allow accessing state for external stack

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -193,6 +193,8 @@ jobs:
           CF_CLIENT_ID: ((cf-client-id-development))
           CF_CLIENT_SECRET: ((cf-client-secret-development))
           TF_VAR_remote_state_bucket: ((tf-state-bucket))
+          TF_VAR_remote_state_reader_access_key_id: ((development-tf-state-access-key-id))
+          TF_VAR_remote_state_reader_secret_access_key: ((development-tf-state-secret-access-key))
           TF_VAR_domain_name: dev.us-gov-west-1.aws-us-gov.cloud.gov
           TF_VAR_iaas_stack_name: development
           TF_VAR_tooling_stack_name: tooling

--- a/terraform/stack/data.tf
+++ b/terraform/stack/data.tf
@@ -17,7 +17,10 @@ data "terraform_remote_state" "tooling" {
 data "terraform_remote_state" "external" {
   backend = "s3"
   config = {
-    bucket = var.remote_state_bucket
-    key    = "${var.external_stack_name}/terraform.tfstate"
+    access_key = var.external_remote_state_reader_access_key_id
+    secret_key = var.external_remote_state_reader_secret_access_key
+    region     = var.csb_aws_region_commercial
+    bucket     = var.remote_state_bucket_external
+    key        = "${var.external_stack_name}/terraform.tfstate"
   }
 }

--- a/terraform/stack/variables.tf
+++ b/terraform/stack/variables.tf
@@ -11,6 +11,17 @@ variable "remote_state_bucket_external" {
   type = string
 }
 
+variable "external_remote_state_reader_access_key_id" {
+  type        = string
+  description = "Access key ID for the IAM user that has permission to read from the state bucket."
+}
+
+variable "external_remote_state_reader_secret_access_key" {
+  type        = string
+  sensitive   = true
+  description = "Secret access key for the IAM user that has permission to read from the state bucket."
+}
+
 variable "external_stack_name" {
   type = string
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Access to external state is required to pull credentials for broker user in commercial account

## security considerations

Stores values in secret store and marks sensitive values as such. 
