### PR TITLE
Explicitly set region for remote state using dedicated var

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -195,6 +195,7 @@ jobs:
           TF_VAR_remote_state_bucket: ((tf-state-bucket))
           TF_VAR_external_remote_state_reader_access_key_id: ((development-tf-state-access-key-id))
           TF_VAR_external_remote_state_reader_secret_access_key: ((development-tf-state-secret-access-key))
+          TF_VAR_external_remote_state_reader_region: ((development-tf-state-region))
           TF_VAR_domain_name: dev.us-gov-west-1.aws-us-gov.cloud.gov
           TF_VAR_iaas_stack_name: development
           TF_VAR_tooling_stack_name: tooling

--- a/terraform/stack/data.tf
+++ b/terraform/stack/data.tf
@@ -19,6 +19,7 @@ data "terraform_remote_state" "external" {
   config = {
     access_key = var.external_remote_state_reader_access_key_id
     secret_key = var.external_remote_state_reader_secret_access_key
+    region     = var.external_remote_state_reader_region
     bucket     = var.remote_state_bucket_external
     key        = "${var.external_stack_name}/terraform.tfstate"
   }

--- a/terraform/stack/variables.tf
+++ b/terraform/stack/variables.tf
@@ -22,6 +22,11 @@ variable "external_remote_state_reader_secret_access_key" {
   description = "Secret access key for the IAM user that has permission to read from the state bucket."
 }
 
+variable "external_remote_state_reader_region" {
+  type        = string
+  description = "The region in which the remote state bucket is located."
+}
+
 variable "external_stack_name" {
   type = string
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Related to https://github.com/cloud-gov/product/issues/2989

## security considerations

Var value stored in secret store.