### PR TITLE
add password write to authorities for opensearcy proxy CI client

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -132,7 +132,7 @@
   value:
     override: true
     authorized-grant-types: client_credentials
-    authorities: scim.write,uaa.admin
+    authorities: scim.write,uaa.admin,password.write
     secret: ((opensearch-dashboards-proxy-ci-secret))
 
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:

- see title

## security considerations

Client will be used to update user passwords from within a pipeline so that passwords for test users do not expire
