### PR TITLE
Create clients to deploy billing service and read CC usage data

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -124,6 +124,36 @@
     name: deploy-csb-client-secret
     type: password
 
+# Used in Concourse to deploy the billing service.
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/deploy-billing?
+  value:
+    override: true
+    authorized-grant-types: client_credentials
+    authorities: cloud_controller.admin
+    secret: ((deploy-billing-client-secret))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: deploy-billing-client-secret
+    type: password
+
+# Use by the billing service to read usage information.
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/billing?
+  value:
+    override: true
+    authorized-grant-types: client_credentials
+    authorities: cloud_controller.admin_read_only
+    secret: ((billing-client-secret))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: billing-client-secret
+    type: password
+
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/uaa-credentials-broker?
   value:


### PR DESCRIPTION
## Changes proposed in this pull request:

- `deploy-billing` will be used in Concourse to deploy the billing service to CF.
- `billing` will be used by the billing service itself to read usage information from all applications and service instances on the platform. It needs read-only permissions.
- Related to https://github.com/cloud-gov/product/issues/3308 and https://github.com/cloud-gov/product/issues/3310
-

## security considerations

Adds two new clients with access to the Cloud.gov CF control plane.