### PR TITLE
Pin CAPI release to 1.215.0

### DIFF
--- a/bosh/opsfiles/pin-capi.yml
+++ b/bosh/opsfiles/pin-capi.yml
@@ -1,18 +1,9 @@
-# Pin CAPI because of valkey
+# Pin CAPI because of Service instance counts on space quotas
 - type: replace
   path: /releases/name=capi
   value:
     name: capi
-    version: 1.183.0
-    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.183.0
-    sha1: fceb5095f6ffc975fe12e0cc36daca00a3cf4db4
+    version: 1.215.0
+    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.215.0
+    sha1: 99d8528d6bce1601093e513544e69be0a29c0500
 
-# Switch to Redis
-- type: remove
-  path: /instance_groups/name=api/jobs/name=valkey
-
-- type: replace
-  path: /instance_groups/name=api/jobs/-
-  value:
-    name: redis
-    release: capi

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -124,6 +124,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/wazuh.yml
             - cf-manifests/bosh/opsfiles/pin-uaa.yml
+            - cf-manifests/bosh/opsfiles/pin-capi.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/development.yml
             - terraform-secrets/terraform.yml
@@ -676,6 +677,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/pin-uaa.yml
+            - cf-manifests/bosh/opsfiles/pin-capi.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/staging.yml
             - terraform-secrets/terraform.yml
@@ -1186,6 +1188,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/pin-uaa.yml
+            - cf-manifests/bosh/opsfiles/pin-capi.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/production.yml
             - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Pin CAPI to a newer release than what is in cf-deployment to address https://github.com/cloudfoundry/cloud_controller_ng/pull/4520
- Part of https://github.com/cloud-gov/product/issues/2836
-

## security considerations
Bumps to a newer version of capi release
