### PR TITLE
Add gatekeeper job for cf-deployment

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -166,6 +166,16 @@ jobs:
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 
+  - name: cf-deployment-gatekeeper
+    serial_groups: [development]
+    serial: true
+    plan:
+      - in_parallel:
+          - get: weekly-timer
+            trigger: true
+          - get: cf-deployment
+            trigger: true
+
   - name: plan-cf-development
     serial_groups: [development]
     serial: true
@@ -175,6 +185,7 @@ jobs:
             trigger: true
           - get: cf-deployment
             trigger: true
+            passed: [cf-deployment-gatekeeper]
           - get: pipeline-tasks
           - get: cf-manifests
             resource: cf-manifests
@@ -1675,6 +1686,16 @@ resources:
       aws_region: us-gov-west-1
       tag: latest
 
+  - name: weekly-timer
+    type: time
+    source:
+      initial_version: true
+      location: America/New_York
+      start: 9:00 AM
+      stop: 9:30 AM
+      days: [Sunday]
+      initial_version: true
+
 resource_types:
   - name: registry-image
     type: registry-image
@@ -1743,6 +1764,7 @@ groups:
   - name: all
     jobs:
       - set-self
+      - cf-deployment-gatekeeper
       - plan-cf-development
       - deploy-cf-development
       - terraform-plan-development
@@ -1776,6 +1798,7 @@ groups:
   - name: development
     jobs:
       - set-self
+      - cf-deployment-gatekeeper
       - plan-cf-development
       - deploy-cf-development
       - terraform-plan-development


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add gatekeeper job for cf-deployment, the job has a weekly timer so cf-deployment is only pulled down once a week to give upstream a bit of time to burn in.  It should also help keep changes to deploy-cf and other resources from getting mixed in as easily with cf-deployment new versions, making it easier to flush certs and other configuration changes.
- This is a "see if it helps", if not, it can easily be removed.
- Part of https://github.com/cloud-gov/product/issues/2836


## security considerations
This only delays when the cf-deployment upstream resource is sucked in.
