### PR TITLE
adding in a platform opensearch ca

### DIFF
--- a/bosh/opsfiles/add-opensearch-platform-ca.yml
+++ b/bosh/opsfiles/add-opensearch-platform-ca.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?/-
+  value: ((/bosh/logs-platform/opensearch_ca.ca))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -120,6 +120,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml
             - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
             - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
+            - cf-manifests/bosh/opsfiles/add-opensearch-platform-ca.yml
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/diego-cell-container-metrics.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- platform CA for opensearch
-
-

## security considerations
Opensearch platform CA needs to have access to gorouter so the CA will be trusted by dashboard and openserch
