### PR TITLE
Remove fog & move to storage-cli

### DIFF
--- a/bosh/opsfiles/use-aws-iam.yml
+++ b/bosh/opsfiles/use-aws-iam.yml
@@ -28,6 +28,10 @@
     use_iam_profile: true
     region: ((aws_region))
 
+# Fun BOSH int/ops file fact - when you create and reference yaml anchors in a single ops file, they are rendered at that time to children
+# so overwriting the yaml anchor in another ops file does not apply to the kids.
+# Hence these explicit overrides here
+
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/connection_config?
   value: *buildpack-blobstore-properties

--- a/bosh/opsfiles/use-aws-iam.yml
+++ b/bosh/opsfiles/use-aws-iam.yml
@@ -1,0 +1,29 @@
+# Overwrite upstream cf-deployment yaml anchor to use iam profile instead of key/secret
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/connection_config?
+  value: &buildpack-blobstore-properties
+    bucket_name: ((buildpack_directory_key))
+    use_iam_profile: true
+    region: ((aws_region))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/connection_config?
+  value: &droplet-blobstore-properties
+    bucket_name: ((droplet_directory_key))
+=   use_iam_profile: true
+    region: ((aws_region))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/connection_config?
+  value: &package-blobstore-properties
+    bucket_name: ((app_package_directory_key))
+    use_iam_profile: true
+    region: ((aws_region))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/connection_config?
+  value: &resource-pool-blobstore-properties
+    bucket_name: ((resource_directory_key))
+    use_iam_profile: true
+    region: ((aws_region))

--- a/bosh/opsfiles/use-aws-iam.yml
+++ b/bosh/opsfiles/use-aws-iam.yml
@@ -27,3 +27,36 @@
     bucket_name: ((resource_directory_key))
     use_iam_profile: true
     region: ((aws_region))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/connection_config?
+  value: *buildpack-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/connection_config?
+  value: *droplet-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/connection_config?
+  value: *package-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/connection_config?
+  value: *resource-pool-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/connection_config?
+  value: *buildpack-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/connection_config?
+  value: *droplet-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/connection_config?
+  value: *package-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/connection_config?
+  value: *resource-pool-blobstore-properties
+

--- a/bosh/opsfiles/use-aws-iam.yml
+++ b/bosh/opsfiles/use-aws-iam.yml
@@ -11,7 +11,7 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/connection_config?
   value: &droplet-blobstore-properties
     bucket_name: ((droplet_directory_key))
-=   use_iam_profile: true
+    use_iam_profile: true
     region: ((aws_region))
 
 - type: replace

--- a/bosh/opsfiles/use-aws-iam.yml
+++ b/bosh/opsfiles/use-aws-iam.yml
@@ -5,7 +5,7 @@
   value: &buildpack-blobstore-properties
     bucket_name: ((buildpack_directory_key))
     use_iam_profile: true
-    server_side_encryption: AES256
+    encryption:: AES256
     region: ((aws_region))
 
 - type: replace
@@ -13,7 +13,7 @@
   value: &droplet-blobstore-properties
     bucket_name: ((droplet_directory_key))
     use_iam_profile: true
-    server_side_encryption: AES256
+    encryption:: AES256
     region: ((aws_region))
 
 - type: replace
@@ -21,7 +21,7 @@
   value: &package-blobstore-properties
     bucket_name: ((app_package_directory_key))
     use_iam_profile: true
-    server_side_encryption: AES256
+    encryption:: AES256
     region: ((aws_region))
 
 - type: replace
@@ -29,7 +29,7 @@
   value: &resource-pool-blobstore-properties
     bucket_name: ((resource_directory_key))
     use_iam_profile: true
-    server_side_encryption: AES256
+    encryption:: AES256
     region: ((aws_region))
 
 # Fun BOSH int/ops file fact - when you create and reference yaml anchors in a single ops file, they are rendered at that time to children

--- a/bosh/opsfiles/use-aws-iam.yml
+++ b/bosh/opsfiles/use-aws-iam.yml
@@ -5,6 +5,7 @@
   value: &buildpack-blobstore-properties
     bucket_name: ((buildpack_directory_key))
     use_iam_profile: true
+    server_side_encryption: AES256
     region: ((aws_region))
 
 - type: replace
@@ -12,6 +13,7 @@
   value: &droplet-blobstore-properties
     bucket_name: ((droplet_directory_key))
     use_iam_profile: true
+    server_side_encryption: AES256
     region: ((aws_region))
 
 - type: replace
@@ -19,6 +21,7 @@
   value: &package-blobstore-properties
     bucket_name: ((app_package_directory_key))
     use_iam_profile: true
+    server_side_encryption: AES256
     region: ((aws_region))
 
 - type: replace
@@ -26,6 +29,7 @@
   value: &resource-pool-blobstore-properties
     bucket_name: ((resource_directory_key))
     use_iam_profile: true
+    server_side_encryption: AES256
     region: ((aws_region))
 
 # Fun BOSH int/ops file fact - when you create and reference yaml anchors in a single ops file, they are rendered at that time to children

--- a/bosh/opsfiles/use-s3-blobstore.yml
+++ b/bosh/opsfiles/use-s3-blobstore.yml
@@ -1,11 +1,8 @@
 ---
 # Modified from https://github.com/cloudfoundry/cf-deployment/blob/master/operations/use-s3-blobstore.yml
-
-# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: remove
   path: /instance_groups/name=singleton-blobstore
 
-# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: remove
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks
 - type: remove
@@ -15,7 +12,6 @@
 - type: remove
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool
 
-# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: remove
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks
 - type: remove
@@ -25,7 +21,6 @@
 - type: remove
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool
 
-# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: remove
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks
 - type: remove
@@ -35,11 +30,9 @@
 - type: remove
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool
 
-# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/fog_connection?
   value: &blobstore-properties
-# We set this - need to FOLLOW UP
     provider: AWS
     use_iam_profile: true
     region: ((aws_region))
@@ -88,17 +81,9 @@
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool?/fog_connection?
   value: *blobstore-properties
 
-# This block is in cf-deployment.yml
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/webdav_config?
   value: &webdav_config
-#cf-deployment adds which we are missing
-            #ca_cert: "((blobstore_tls.ca))"
-            #blobstore_timeout: 5
-            #password: "((blobstore_admin_users_password))"
-            #private_endpoint: https://blobstore.service.cf.internal:4443
-            #public_endpoint: https://blobstore.((system_domain))
-            #username: blobstore-user
     public_endpoint: blobstore.((system_domain))
 
 - type: replace
@@ -144,10 +129,6 @@
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/webdav_config?
   value: *webdav_config
-
-
-# taken out by cf-deployment/operations/use-external-blobstore.yml
-# variable names are the same
 
 # replace s3 bucket names
 - type: replace
@@ -197,9 +178,6 @@
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/resource_directory_key?
   value: ((resource_directory_key))
-
-# taken out by cf-deployment/operations/use-external-blobstore.yml
-# we are missing removal of path: /variables/name=blobstore_public
 
 # remove unnecessary variables for internal blobstore
 

--- a/bosh/opsfiles/use-s3-blobstore.yml
+++ b/bosh/opsfiles/use-s3-blobstore.yml
@@ -1,8 +1,11 @@
 ---
 # Modified from https://github.com/cloudfoundry/cf-deployment/blob/master/operations/use-s3-blobstore.yml
+
+# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: remove
   path: /instance_groups/name=singleton-blobstore
 
+# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: remove
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks
 - type: remove
@@ -12,6 +15,7 @@
 - type: remove
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool
 
+# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: remove
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks
 - type: remove
@@ -21,6 +25,7 @@
 - type: remove
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool
 
+# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: remove
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks
 - type: remove
@@ -30,9 +35,11 @@
 - type: remove
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool
 
+# taken out by cf-deployment/operations/use-external-blobstore.yml
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/fog_connection?
   value: &blobstore-properties
+# We set this - need to FOLLOW UP
     provider: AWS
     use_iam_profile: true
     region: ((aws_region))
@@ -81,9 +88,17 @@
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool?/fog_connection?
   value: *blobstore-properties
 
+# This block is in cf-deployment.yml
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/webdav_config?
   value: &webdav_config
+#cf-deployment adds which we are missing
+            #ca_cert: "((blobstore_tls.ca))"
+            #blobstore_timeout: 5
+            #password: "((blobstore_admin_users_password))"
+            #private_endpoint: https://blobstore.service.cf.internal:4443
+            #public_endpoint: https://blobstore.((system_domain))
+            #username: blobstore-user
     public_endpoint: blobstore.((system_domain))
 
 - type: replace
@@ -129,6 +144,10 @@
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/webdav_config?
   value: *webdav_config
+
+
+# taken out by cf-deployment/operations/use-external-blobstore.yml
+# variable names are the same
 
 # replace s3 bucket names
 - type: replace
@@ -178,6 +197,9 @@
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/resource_directory_key?
   value: ((resource_directory_key))
+
+# taken out by cf-deployment/operations/use-external-blobstore.yml
+# we are missing removal of path: /variables/name=blobstore_public
 
 # remove unnecessary variables for internal blobstore
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -71,7 +71,9 @@ jobs:
             - router-main/router_main.yml
             - router-logstash/router_logstash.yml
             - cf-deployment/operations/rename-network-and-deployment.yml
-            - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
+            - cf-deployment/operations/use-external-blobstore.yml
+            - cf-deployment/operations/use-s3-blobstore.yml
+            - cf-manifests/bosh/opsfiles/use-aws-iam.yml 
             - cf-deployment/operations/use-external-dbs.yml
             - cf-deployment/operations/stop-skipping-tls-validation.yml
             - cf-deployment/operations/set-bbs-active-key.yml
@@ -672,7 +674,9 @@ jobs:
             - router-main/router_main.yml
             - router-logstash/router_logstash.yml
             - cf-deployment/operations/rename-network-and-deployment.yml
-            - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
+            - cf-deployment/operations/use-external-blobstore.yml
+            - cf-deployment/operations/use-s3-blobstore.yml
+            - cf-manifests/bosh/opsfiles/use-aws-iam.yml 
             - cf-deployment/operations/use-external-dbs.yml
             - cf-deployment/operations/stop-skipping-tls-validation.yml
             - cf-deployment/operations/set-bbs-active-key.yml
@@ -1217,7 +1221,9 @@ jobs:
             - router-main/router_main.yml
             - router-logstash/router_logstash.yml
             - cf-deployment/operations/rename-network-and-deployment.yml
-            - cf-manifests/bosh/opsfiles/use-s3-blobstore.yml
+            - cf-deployment/operations/use-external-blobstore.yml
+            - cf-deployment/operations/use-s3-blobstore.yml
+            - cf-manifests/bosh/opsfiles/use-aws-iam.yml 
             - cf-deployment/operations/use-external-dbs.yml
             - cf-deployment/operations/stop-skipping-tls-validation.yml
             - cf-deployment/operations/set-bbs-active-key.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Configure `deploy-cf` pipeline to use upstream cf-deployment ops files for s3 based external blobstore
- Configure custom ops file for using IAM profile
- Update pipeline to use the correct ops files

Ticket for work: https://github.com/cloud-gov/product/issues/3487

## security considerations
The `fog` gem is no longer maintained so by keeping up with upstream cf-deployment using the `storage-cli` we stay on maintained code
