### PR TITLE
Add falco to prod platform and devtools cells

### DIFF
--- a/bosh/opsfiles/falco-platform-and-devtools-only.yml
+++ b/bosh/opsfiles/falco-platform-and-devtools-only.yml
@@ -1,0 +1,41 @@
+- path: /releases?/name=falco
+  type: replace
+  value:
+    name: falco
+    version: latest
+
+- type: replace
+  path: /instance_groups/name=diego-platform-cell/jobs?/name=falco-cf-logger/release
+  value: falco
+
+- type: replace
+  path: /instance_groups/name=diego-cell-iso-seg-devtools/jobs?/name=falco-cf-logger/release
+  value: falco
+
+- type: replace
+  path: /instance_groups/name=diego-platform-cell/jobs?/name=falco/release
+  value: falco
+
+- type: replace
+  path: /instance_groups/name=diego-cell-iso-seg-devtools/jobs?/name=falco/release
+  value: falco
+
+- type: replace
+  path: /instance_groups/name=diego-platform-cell/jobs?/name=falcosidekick
+  value:
+    name: falcosidekick
+    release: falco
+    properties:
+      aws:
+        s3:
+          bucket: logs-opensearch-falco-((environment))
+
+- type: replace
+  path: /instance_groups/name=diego-cell-iso-seg-devtools/jobs?/name=falcosidekick
+  value:
+    name: falcosidekick
+    release: falco
+    properties:
+      aws:
+        s3:
+          bucket: logs-opensearch-falco-((environment))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1271,6 +1271,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/diego-cell-container-metrics.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/diego-api.yml
+            - cf-manifests/bosh/opsfiles/falco-platform-and-devtools-only.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/production.yml
             - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds ops file to add falco to platform and devtools cells
- Part of https://github.com/cloud-gov/private/issues/2848
-

## security considerations
Adds requested falco configuration to non-customer facing application diego-cells
