### PR TITLE
Pin java buildpack to v4 and stemcell to jammy

### DIFF
--- a/bosh/opsfiles/pin-java-buildpack.yml
+++ b/bosh/opsfiles/pin-java-buildpack.yml
@@ -1,0 +1,7 @@
+- path: /releases?/name=java-buildpack
+  type: replace
+  value:
+    name: java-buildpack
+    url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.77.0
+    version: 4.77.0
+    sha1: b4b8e169526b42f3064e389c09921861ab946dc6

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -127,6 +127,8 @@ jobs:
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/diego-api.yml
             - cf-manifests/bosh/opsfiles/falco.yml
+            - cf-deployment/operations/use-jammy-stemcell.yml
+            - cf-manifests/bosh/opsfiles/pin-java-buildpack.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/development.yml
             - terraform-secrets/terraform.yml
@@ -726,6 +728,8 @@ jobs:
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/diego-api.yml
             - cf-manifests/bosh/opsfiles/falco.yml
+            - cf-deployment/operations/use-jammy-stemcell.yml
+            - cf-manifests/bosh/opsfiles/pin-java-buildpack.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/staging.yml
             - terraform-secrets/terraform.yml
@@ -1272,6 +1276,8 @@ jobs:
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/diego-api.yml
             - cf-manifests/bosh/opsfiles/falco-platform-and-devtools-only.yml
+            - cf-deployment/operations/use-jammy-stemcell.yml
+            - cf-manifests/bosh/opsfiles/pin-java-buildpack.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/production.yml
             - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Noble is now the default stemcell, use the provided ops file to revert to jammy
- We do not yet want to use the v5.0.1 java buildpack so pinning to the most recent stable version
- Part of https://github.com/cloud-gov/private/issues/2925

## security considerations
There should not be any changes to security, pins to what we are currently using
