### PR TITLE
Pin CAPI to 1.234.0

### DIFF
--- a/bosh/opsfiles/pin-capi.yml
+++ b/bosh/opsfiles/pin-capi.yml
@@ -4,7 +4,7 @@
   path: /releases/name=capi
   value:
     name: capi
-    version: 1.215.0
-    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.215.0
-    sha1: 99d8528d6bce1601093e513544e69be0a29c0500
+    version: 1.234.0
+    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.234.0
+    sha1: sha256:6d90ccb4fe16dd6d7abb550c480ffb37e5a3675ff9e5df8cefbc9e379bb10f4b
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -129,6 +129,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/falco.yml
             - cf-deployment/operations/use-jammy-stemcell.yml
             - cf-manifests/bosh/opsfiles/pin-java-buildpack.yml
+            - cf-manifests/bosh/opsfiles/pin-capi.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/development.yml
             - terraform-secrets/terraform.yml
@@ -730,6 +731,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/falco.yml
             - cf-deployment/operations/use-jammy-stemcell.yml
             - cf-manifests/bosh/opsfiles/pin-java-buildpack.yml
+            - cf-manifests/bosh/opsfiles/pin-capi.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/staging.yml
             - terraform-secrets/terraform.yml
@@ -1278,6 +1280,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/falco-platform-and-devtools-only.yml
             - cf-deployment/operations/use-jammy-stemcell.yml
             - cf-manifests/bosh/opsfiles/pin-java-buildpack.yml
+            - cf-manifests/bosh/opsfiles/pin-capi.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/production.yml
             - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Pin CAPI to 1.234.0, the version in cf-deployment (1.232.0) has db migration issues
- Part of https://github.com/cloud-gov/private/issues/2927
-

## security considerations
Patches forward to a version of CAPI without db migration issues
