### PR TITLE
Pin capi to v1.231.0

### DIFF
--- a/bosh/opsfiles/pin-capi.yml
+++ b/bosh/opsfiles/pin-capi.yml
@@ -4,7 +4,6 @@
   path: /releases/name=capi
   value:
     name: capi
-    version: 1.234.0
-    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.234.0
-    sha1: sha256:6d90ccb4fe16dd6d7abb550c480ffb37e5a3675ff9e5df8cefbc9e379bb10f4b
-
+    version: 1.231.0
+    url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.231.0
+    sha1: sha256:797f328d5229545c515f5d9c7760f6be6237e841566989ebfe6d058776c231b8


### PR DESCRIPTION
## Changes proposed in this pull request:
- Pin capi to v1.231.0
- Removes v1.234.0 which has inconsistencies in app manifests with multiple buildpacks
- Part of https://github.com/cloud-gov/product/issues/2836
-

## security considerations
Rolls back to a previously used version
