### PR TITLE
bump disk

### DIFF
--- a/bosh/opsfiles/api-defaults.yml
+++ b/bosh/opsfiles/api-defaults.yml
@@ -8,7 +8,7 @@
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_app_disk_in_mb?
-  value: 7168
+  value: 10240
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/min_recommended_cli_version?
@@ -17,7 +17,7 @@
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?
-  value: 7168
+  value: 10240
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/client_max_body_size?
@@ -25,7 +25,7 @@
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/maximum_app_disk_in_mb?
-  value: 7168
+  value: 10240
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/thresholds?


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bump max disk to 10GB from 7GB
- Only 4% of apps use the max and they all use the extra space then we would still have ~70TB of disk capacity left.
- Part of https://github.com/cloud-gov/private/issues/2943

## security considerations
None