### PR TITLE
Add login.gov to primary uaa-oauth-providers ops file, remove temporary one

### DIFF
--- a/bosh/opsfiles/uaa-oauth-providers-v2.yml
+++ b/bosh/opsfiles/uaa-oauth-providers-v2.yml
@@ -1,5 +1,0 @@
-- type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/oauth?/providers?
-  value:
-    ssa.gov: ((uaa-oidc-provider-ssa-gov))
-    login.gov: ((uaa-oidc-provider-login-gov))

--- a/bosh/opsfiles/uaa-oauth-providers.yml
+++ b/bosh/opsfiles/uaa-oauth-providers.yml
@@ -2,3 +2,4 @@
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/oauth?/providers?
   value:
     ssa.gov: ((uaa-oidc-provider-ssa-gov))
+    login.gov: ((uaa-oidc-provider-login-gov))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -696,7 +696,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/uaa-groups.yml
             - cf-manifests/bosh/opsfiles/uaa-login.yml
             - cf-manifests/bosh/opsfiles/uaa-saml.yml
-            - cf-manifests/bosh/opsfiles/uaa-oauth-providers-v2.yml
+            - cf-manifests/bosh/opsfiles/uaa-oauth-providers.yml
             - cf-manifests/bosh/opsfiles/uaa-user.yml
             - cf-manifests/bosh/opsfiles/uaa-cors.yml
             - cf-manifests/bosh/opsfiles/sql.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add login.gov to primary uaa-oauth-providers ops file, remove temporary one
- This enables the login.gov IdP for both staging and production
- Part of https://github.com/cloud-gov/private/issues/2771

## security considerations
Formalizes configuration already tested manually, secrets/config of the idp are in credhub
