### PR TITLE
Add scim.write for the login-migrator-bot client

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -304,7 +304,7 @@
   value:
     override: true
     authorized-grant-types: client_credentials
-    authorities: cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,scim.read
+    authorities: cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,scim.read,scim.write
     secret: ((login-migrator-bot-client-secret))
 
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `scim.write` which is needed for the login-migrator-bot client to be able to remove the old cloud.gov idp entries
- Part of https://github.com/cloud-gov/private/issues/2775
-

## security considerations
Secrets controlled by credhub still
