### PR TITLE
Show unredacted bosh diff across all environments

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -61,6 +61,7 @@ jobs:
           ISO_SEG_NAMES: ((names_of_iso_segs_development))
       - put: cf-deployment-development
         params: &deploy-params
+          no_redact: true
           manifest: cf-deployment/cf-deployment.yml
           releases:
             - uaa-customized-release/*.tgz


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `no_redact: true` to the shared `&deploy-params` anchor in `ci/pipeline.yml`. Because every deploy job merges this anchor (`<<: *deploy-params`, and production's `&prod-deploy-params` which itself extends it), this enables the unredacted BOSH deploy diff across **all environments** — development, staging, and production — for both the dry-run plan jobs and the real deploy jobs.

## Why
- Operators currently deploy effectively blind: the redacted diff hides what changes are actually going to be applied. Showing the full, unredacted BOSH diff lets operators review exactly what will change before it is applied, rather than approving deploys sight-unseen. Deploying without visibility into the pending changes makes every deploy riskier.

## security considerations
- This change is safe. Secrets are no longer stored in S3 — all secrets for this pipeline are sourced from CredHub. Disabling redaction on the BOSH diff therefore does not expose secret material in pipeline output. This holds across all environments (development, staging, and production).

---
*This PR was prepared with AI assistance (OpenCode agent). Human review required before merge.*