### PR TITLE
Revert starlette to 0.49.1 for fastapi 0.120.1 compatibility

### DIFF
--- a/ci/test-space-egress/requirements.txt
+++ b/ci/test-space-egress/requirements.txt
@@ -20,7 +20,7 @@ pyparsing==2.4.7
 regex==2021.8.28
 requests==2.33.0
 six==1.16.0
-starlette==1.3.1
+starlette==0.49.1
 tomli==1.2.1
 typing-extensions==4.15.0
 urllib3==2.7.0


### PR DESCRIPTION
Dependabot PR #1093 bumped starlette 0.49.1 -> 1.3.1, but the pinned
fastapi==0.120.1 requires starlette<0.50.0,>=0.40.0. This broke the
test-space-egress pipeline at the buildpack compile phase with a pip
ResolutionImpossible error. No published fastapi release yet supports
the starlette 1.x line, so pin back to the highest compatible 0.4x.

Fixes the test-space-egress-development pipeline BuildpackCompileFailed.
